### PR TITLE
Add The Wilmington Papers + reusable papers site generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@ _site
 .DS_STORE
 
 .omc/
+
+__pycache__/
+*.pyc
+
+# Raw dinner notes are the private source; only generated pages are published.
+the_wilmington_papers/granola_notes/
+*/granola_notes/
+
+# Parsed note data is derived; regenerate with _tools/papers/build.py
+*/_data/
+
+# Real names / suppression patterns are a decoder ring for redacted output.
+trip.private.json
+**/trip.private.json

--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,10 @@ markdown: kramdown
 gems:
   - bourbon
   - neat
+
+# Raw dinner notes and the parsed data they produce are private source material.
+# Only the generated pages are published.
+exclude:
+  - "**/granola_notes"
+  - "**/_data"
+  - _tools

--- a/_tools/papers/README.md
+++ b/_tools/papers/README.md
@@ -12,42 +12,58 @@ here is specific to that trip. A new trip is a folder and a `trip.json`.
 ```
 mkdir -p the_reno_papers/granola_notes
 # drop one .md per dinner into granola_notes/
-# write the_reno_papers/trip.json  (see below)
+# write the_reno_papers/trip.json          (public config, see below)
+# write the_reno_papers/trip.private.json  (names to redact, gitignored)
 
 python3 _tools/papers/build.py the_reno_papers --check   # parse, report, write nothing
 python3 _tools/papers/build.py the_reno_papers           # write the pages
+
+git ls-files the_reno_papers | xargs grep -il "<a real name>"   # expect no output
 ```
+
+Run that last line before every push. It is the check that catches a name
+reaching a tracked file, and it is cheap compared to un-publishing one.
 
 Output lands in the trip folder: `index.html`, `record.html`,
 `cold-cases.html`, `canon.html`, `quotable.html`, and `dinners/<slug>.html`.
 Jekyll passes these through untouched, so the folder is live at
-`hjeebus.com/<trip>/` once pushed. Re-running is safe and idempotent — it
+`www.hjeeb.us/<trip>/` once pushed. Re-running is safe and idempotent — it
 overwrites its own output and never edits the notes.
 
 `_data/dinners.json` is also written: the parsed notes as structured data, handy
-for grepping or feeding something else.
+for grepping or feeding something else. It stays out of git along with the notes.
 
 ## trip.json
 
 Every reader-visible string comes from here. All keys are optional except that
 you'll want a `title`.
 
-| key | what it does |
-| --- | --- |
-| `title` | Site title, `<title>` suffix, footer |
-| `tagline` | Home-page dek and meta description |
-| `footer` | Second footer segment, e.g. `field notes, Aug 2026` |
-| `notes_dir` | Notes subfolder (default `granola_notes`) |
-| `noindex` | `true` adds `<meta name="robots" content="noindex,nofollow">` |
-| `order` | Slugs in reading order; omit to sort by date |
-| `venues` | Per-slug `{name, kind, date}` overrides |
-| `hero_quote` | Prefix of the line to feature as Exhibit A |
-| `facts` | Extra masthead counts: `[{n, label}]` |
-| `closing_stat` | Fourth home stat `{n, label}`; omit for a computed one |
-| `threads` | `{label: regex}` — recurring subjects to track |
-| `thread_min_sittings` | Sittings a thread needs to appear (default 2) |
-| `companion_aliases` | `{"Real Name": ["variant", ...]}` spelling fixes |
-| `sections` | Per-page `kicker` / `title` / `dek` overrides |
+Anything holding a real name or a verbatim quote belongs in
+`trip.private.json`, which is gitignored and merged over this file at build
+time. The `file` column says where each key goes.
+
+| key | file | what it does |
+| --- | --- | --- |
+| `title` | public | Site title, `<title>` suffix, footer |
+| `tagline` | public | Home-page dek and meta description |
+| `footer` | public | Second footer segment, e.g. `field notes, Aug 2026` |
+| `notes_dir` | public | Notes subfolder (default `granola_notes`) |
+| `noindex` | public | `true` adds `<meta name="robots" content="noindex,nofollow">` |
+| `order` | public | Slugs in reading order; omit to sort by date |
+| `venues` | public | Per-slug `{name, kind, date}` overrides |
+| `facts` | public | Extra masthead counts: `[{n, label}]` |
+| `closing_stat` | public | Fourth home stat `{n, label}`; omit for a computed one |
+| `threads` | public | `{label: regex}` — recurring subjects to track |
+| `thread_min_sittings` | public | Sittings a thread needs to appear (default 2) |
+| `sections` | public | Per-page `kicker` / `title` / `dek` overrides |
+| `drop_sections` | public | Section field names to omit entirely |
+| `hero_quote` | **private** | Prefix of the line to feature as Exhibit A |
+| `companion_aliases` | **private** | `{"Real Name": ["variant", ...]}` spelling fixes |
+| `redact_names` | **private** | `{"Real Name": "stand-in"}` replacements |
+| `suppress` | **private** | Patterns whose matching entries are withheld |
+
+`drop_sections` is public because a field name reveals nothing; `suppress`
+patterns are private because they quote the text they are withholding.
 
 `dek` strings may reference `{questions}`, `{loops}`, `{theories}`,
 `{quotes}`, and `{dinners}`.
@@ -94,8 +110,43 @@ After changing any of this, audit what would actually ship:
 git ls-files <trip> | xargs grep -il "<a real name>"
 ```
 
-Expect no matches. Note that redaction only affects generated output — it cannot
-retract anything already pushed, so decide before the first push.
+Expect no matches.
+
+### Redact before the first push
+
+Redaction only shapes generated output. It cannot retract anything already
+pushed, and checking the current working tree is not enough — **every past
+commit is still readable.** Pages generated before a redaction rule existed keep
+the un-redacted text in their history, so a repo whose tip is clean can still
+serve the original wording from an earlier commit.
+
+To audit history rather than just the tip:
+
+```
+git log --remotes --oneline -S "<a real name>"   # what is actually published
+git log --all --oneline -S "<a real name>"       # includes local-only commits
+```
+
+Use `--remotes` to answer "is this public?". Prefer `--all` only when you also
+want local commits — after a squash and force-push the replaced commits linger in
+your own reflog until git collects them, so `--all` reports names that are no
+longer reachable from anywhere on the remote.
+
+Any output from the `--remotes` form means the name is still published. On an
+unmerged branch the fix is to squash to a single commit built from redacted
+output and force-push; on shared history it is far more disruptive. Either way,
+assume anything briefly public may have been fetched, forked, or cached.
+
+Also note that a public repo serves the notes two ways: through the repo itself,
+and through Jekyll, which renders `.md` files as pages. The gitignore entries
+handle the first and the `exclude:` list in `_config.yml` handles the second.
+Both are needed.
+
+`noindex: true` in a trip's config adds `<meta name="robots" content="noindex,
+nofollow">` to every page of that trip. Useful when the notes cover events that
+are searchable in their own right — anonymizing the guests does nothing about
+the incidents around them. It keeps the pages live and link-shareable while
+keeping them out of results, and it is reversible with a rebuild.
 
 ## Deep links
 

--- a/_tools/papers/README.md
+++ b/_tools/papers/README.md
@@ -1,0 +1,151 @@
+# papers
+
+Turns a folder of Granola dinner notes into a static "case file" site: the
+dinners themselves, plus pages that cut *across* them (every unanswered
+question, every unverified claim, every good line).
+
+Built for [the_wilmington_papers](../../the_wilmington_papers/), but nothing in
+here is specific to that trip. A new trip is a folder and a `trip.json`.
+
+## Adding a trip
+
+```
+mkdir -p the_reno_papers/granola_notes
+# drop one .md per dinner into granola_notes/
+# write the_reno_papers/trip.json  (see below)
+
+python3 _tools/papers/build.py the_reno_papers --check   # parse, report, write nothing
+python3 _tools/papers/build.py the_reno_papers           # write the pages
+```
+
+Output lands in the trip folder: `index.html`, `record.html`,
+`cold-cases.html`, `canon.html`, `quotable.html`, and `dinners/<slug>.html`.
+Jekyll passes these through untouched, so the folder is live at
+`hjeebus.com/<trip>/` once pushed. Re-running is safe and idempotent — it
+overwrites its own output and never edits the notes.
+
+`_data/dinners.json` is also written: the parsed notes as structured data, handy
+for grepping or feeding something else.
+
+## trip.json
+
+Every reader-visible string comes from here. All keys are optional except that
+you'll want a `title`.
+
+| key | what it does |
+| --- | --- |
+| `title` | Site title, `<title>` suffix, footer |
+| `tagline` | Home-page dek and meta description |
+| `footer` | Second footer segment, e.g. `field notes, Aug 2026` |
+| `notes_dir` | Notes subfolder (default `granola_notes`) |
+| `noindex` | `true` adds `<meta name="robots" content="noindex,nofollow">` |
+| `order` | Slugs in reading order; omit to sort by date |
+| `venues` | Per-slug `{name, kind, date}` overrides |
+| `hero_quote` | Prefix of the line to feature as Exhibit A |
+| `facts` | Extra masthead counts: `[{n, label}]` |
+| `closing_stat` | Fourth home stat `{n, label}`; omit for a computed one |
+| `threads` | `{label: regex}` — recurring subjects to track |
+| `thread_min_sittings` | Sittings a thread needs to appear (default 2) |
+| `companion_aliases` | `{"Real Name": ["variant", ...]}` spelling fixes |
+| `sections` | Per-page `kicker` / `title` / `dek` overrides |
+
+`dek` strings may reference `{questions}`, `{loops}`, `{theories}`,
+`{quotes}`, and `{dinners}`.
+
+Minimum viable config:
+
+```json
+{
+  "title": "The Reno Papers",
+  "tagline": "Four nights. Nothing was resolved.",
+  "threads": { "the bet": "blackjack|the bet" }
+}
+```
+
+## Privacy
+
+The notes are the private source; only generated pages are published. These are
+gitignored and excluded from the Jekyll build:
+
+- `<trip>/granola_notes/` — the raw notes
+- `<trip>/_data/` — parsed note data, regenerate any time
+- `<trip>/trip.private.json` — real names and suppression patterns
+
+That last one matters: a name-to-initial map is a decoder ring for the redacted
+pages, so publishing it would defeat the redaction. Keep it out of the repo.
+`trip.private.json` is merged over `trip.json` at build time (dicts merge, lists
+concatenate), so put anything sensitive there and nothing else changes.
+
+Three controls, applied in this order:
+
+| key | effect |
+| --- | --- |
+| `suppress` | Drops individual entries matching a substring or regex, leaving the rest of the section intact |
+| `redact_names` | Replaces `{"Real Name": "stand-in"}` throughout, longest name first |
+| `drop_sections` | Omits whole sections by field name, e.g. `["undercurrent"]` |
+
+`suppress` runs before `redact_names` so patterns match the original wording.
+Replacements are word-bounded and case-sensitive, and obvious artifacts (`B..`,
+`the server the server`) are cleaned up automatically.
+
+After changing any of this, audit what would actually ship:
+
+```
+git ls-files <trip> | xargs grep -il "<a real name>"
+```
+
+Expect no matches. Note that redaction only affects generated output — it cannot
+retract anything already pushed, so decide before the first push.
+
+## Deep links
+
+Every quote, question, loop, claim, and side quest gets a stable `id`, so any
+single item is linkable:
+
+```
+.../quotable.html#x-dbdd7262      one line
+.../cold-cases.html#q-4a1c33f0    one unanswered question
+.../canon.html#c-9e2b71dd         one claim
+```
+
+Hovering an item reveals a `#` handle carrying that URL. The prefix marks the
+kind (`x` line, `q` question, `l` loop, `p` promised, `c` claim, `s` side
+quest); the suffix is a hash of the item's own text.
+
+Because the id derives from the text and not from position, it survives
+reordering and new dinners, and the same quote has the same id on Quotable and
+on its dinner page. Rewording an item does change its id — links to the old
+wording will no longer resolve.
+
+On Quotable, opening a `#x-...` URL shows that specific line instead of a
+random one, and pulling a new line updates the address bar so whatever is on
+screen is always what gets copied.
+
+## What the parser expects
+
+Granola's default export shape — an `# H1` venue name, a
+`Sun, 09 Aug 26 · Companion Name` byline, then `### ` sections. Recognized
+headings (see `SECTION_MAP` in `parse.py`):
+
+`Attendees`, `Setting and Vibe`, `Main Conversation Threads`,
+`Stories Started`, `Best Lines and Bits`, `Theories and Claims`,
+`Side Quests`, `Emotional Undercurrents`, `Unanswered Questions`,
+`Things People Promised To Send`, `Open Loops`, `Decisions or Plans`,
+`Next Dinner`.
+
+Anything else is kept and rendered at the bottom of that dinner's page rather
+than dropped, so an unfamiliar section is visible instead of silently lost.
+
+Handled automatically: missing sections, missing bylines, absent dates,
+straight *and* curly quotes, attributions in trailing parentheses, speaker
+lead-ins (`The server, on the burrata: "..."`), and notes accidentally pasted
+several times in one file (identical repeats collapse to one).
+
+Sections whose only content is a variant of "No firm decisions" render as quiet
+italics instead of a one-item list.
+
+## Files
+
+- `build.py` — CLI, page generation
+- `parse.py` — notes to structured records
+- `theme.py` — inline CSS and page chrome

--- a/_tools/papers/build.py
+++ b/_tools/papers/build.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Build a case-file site from a folder of Granola dinner notes.
+
+    python3 _tools/papers/build.py the_wilmington_papers
+
+Reads `<trip>/trip.json` plus `<trip>/granola_notes/*.md` and writes the five
+top-level pages and one page per dinner into `<trip>/`. Every string shown to a
+reader comes from trip.json, so a new trip is config plus notes and no code.
+
+Pass `--check` to validate and report without writing files. Generated markup
+carries all content inline; the theme toggle and quote shuffle are the only
+scripted behavior and the pages remain complete with JavaScript disabled.
+"""
+import argparse
+import hashlib
+import html
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from parse import load_trip
+from theme import CSS, TABS, THEME_JS
+
+ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII",
+         "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX"]
+MONTH_ABBR = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+              "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
+
+DEFAULTS = {
+    "title": "The Papers",
+    "tagline": "Dinners, transcribed and entered into evidence.",
+    "footer": "field notes",
+    "noindex": False,
+    "sections": {
+        "cold_cases": {
+            "kicker": "Section I - unresolved",
+            "title": "Cold Cases",
+            "dek": "{questions} questions asked and never answered. {loops} loops left open.",
+        },
+        "record": {
+            "kicker": "Section II",
+            "title": "The Record",
+            "dek": "{dinners} sittings, chronological. Each one catalogued in full.",
+        },
+        "canon": {
+            "kicker": "Section III - the record of claims",
+            "title": "Canon",
+            "dek": "{theories} assertions made with total confidence and zero verification.",
+        },
+        "quotable": {
+            "kicker": "Section IV",
+            "title": "Quotable",
+            "dek": "Every line worth preserving, served one at a time.",
+        },
+    },
+}
+
+
+def e(s):
+    return html.escape(str(s), quote=True)
+
+
+def merge(base, over):
+    out = dict(base)
+    for k, v in (over or {}).items():
+        out[k] = merge(base[k], v) if isinstance(v, dict) and isinstance(base.get(k), dict) else v
+    return out
+
+
+def datestamp(iso):
+    if not iso:
+        return ""
+    try:
+        y, m, d = iso.split("-")
+        return "%d %s %s" % (int(d), MONTH_ABBR[int(m) - 1], y)
+    except (ValueError, IndexError):
+        return iso
+
+
+def roman(i):
+    return ROMAN[i] if i < len(ROMAN) else str(i + 1)
+
+
+def total(dinners, key):
+    return sum(len(d.get(key) or []) for d in dinners)
+
+
+def real_items(dinners, key):
+    """Yield (dinner, item) skipping sections that only say 'nothing'."""
+    for d in dinners:
+        if d.get(key + "_empty"):
+            continue
+        for item in d.get(key) or []:
+            yield d, item
+
+
+# ---------------------------------------------------------------- threads
+
+def find_threads(dinners, probes, min_hits=2):
+    """Match configured regexes against each dinner; keep multi-sitting hits."""
+    out = []
+    for label, pattern in (probes or {}).items():
+        try:
+            rx = re.compile(pattern, re.I)
+        except re.error:
+            print("  ! bad regex for thread %r, skipped" % label, file=sys.stderr)
+            continue
+        hits = [d for d in dinners if rx.search(json.dumps(d, ensure_ascii=False))]
+        if len(hits) >= min_hits:
+            out.append((label, hits))
+    return sorted(out, key=lambda kv: -len(kv[1]))
+
+
+# ---------------------------------------------------------------- chrome
+
+def page(cfg, title, body, current, depth=0):
+    up = "../" * depth
+    tabs = "".join(
+        '<a href="%s%s"%s>%s</a>' % (
+            up, href, ' aria-current="page"' if key == current else "", e(label))
+        for href, label, key in TABS
+    )
+    tabs += '<a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a>'
+    robots = ('\n<meta name="robots" content="noindex,nofollow">'
+              if cfg.get("noindex") else "")
+    return """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>%s</title>
+<meta name="description" content="%s">%s
+<style>%s</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs">%s</nav>
+%s
+<footer class="foot">
+  %s &middot; %s &middot; <a href="%sindex.html">return to file</a>
+</footer>
+</div>
+<script>%s</script>
+</body>
+</html>
+""" % (e(title), e(cfg["tagline"][:150]), robots, CSS, tabs, body,
+       e(cfg["title"]), e(cfg["footer"]), up, THEME_JS)
+
+
+def suffix(cfg):
+    return " - " + cfg["title"]
+
+
+# ---------------------------------------------------------------- pages
+
+def build_home(cfg, dinners, threads):
+    nq = total(dinners, "quotes")
+    stats = {
+        "questions": total(dinners, "questions"),
+        "loops": total(dinners, "loops"),
+        "theories": total(dinners, "theories"),
+        "dinners": len(dinners),
+    }
+
+    hero, hero_d = None, None
+    want = cfg.get("hero_quote", "")
+    for d in dinners:
+        for q in d["quotes"]:
+            if want and q["text"].startswith(want):
+                hero, hero_d = q, d
+    if hero is None:
+        for d in dinners:
+            if d["quotes"]:
+                hero, hero_d = d["quotes"][0], d
+                break
+
+    facts = "".join(
+        "<span><b>%s</b> %s</span>" % (e(v), e(k))
+        for k, v in [
+            ("dinners", len(dinners)),
+            ("venues", len({d["venue"] for d in dinners})),
+            ("days", len({d["date"] for d in dinners if d["date"]})),
+        ]
+    )
+    for f in cfg.get("facts", []):
+        facts += "<span><b>%s</b> %s</span>" % (e(f.get("n", "")), e(f.get("label", "")))
+
+    body = """
+<header class="mast">
+  <div class="kicker">Exhibits 1&ndash;%d &middot; entered into evidence</div>
+  <h1 class="title">%s</h1>
+  <p class="dek">%s</p>
+  <div class="mast-meta">%s</div>
+</header>
+""" % (nq, e(cfg["title"]), e(cfg["tagline"]), facts)
+
+    if hero:
+        body += """
+<div class="exhibit">
+  <p class="q">&ldquo;%s&rdquo;</p>
+  <div class="src">Exhibit A &middot; %s &middot; %s</div>
+</div>
+""" % (e(hero["text"]), e(hero_d["venue"]), datestamp(hero_d["date"]))
+
+    rows = [
+        (stats["questions"], "questions unanswered"),
+        (stats["loops"], "loops left open"),
+        (stats["theories"], "claims on record"),
+    ]
+    kicker = cfg.get("closing_stat")
+    if kicker:
+        rows.append((kicker.get("n", 0), kicker.get("label", "")))
+    else:
+        rows.append((sum(1 for d in dinners if not d.get("decisions_empty")),
+                     "nights with a decision"))
+
+    body += '<div class="stat-row">'
+    for n, label in rows:
+        body += '<div class="stat"><b>%s</b><span>%s</span></div>' % (e(n), e(label))
+    body += "</div>"
+
+    if threads:
+        body += ('<h2 class="sec">Recurring threads</h2>'
+                 '<p class="sec-note">Subjects that refused to die across multiple sittings.</p>'
+                 '<hr class="rule">')
+        for label, ds in threads:
+            where = ", ".join(
+                '<a href="dinners/%s.html">%s</a>' % (e(d["slug"]), e(d["venue"])) for d in ds)
+            body += ('<div class="thread"><h3>%s <span class="count">%d sittings</span></h3>'
+                     '<div class="where">%s</div></div>') % (e(label), len(ds), where)
+
+    sec = cfg["sections"]
+    body += '<h2 class="sec">Where to start</h2><hr class="rule"><div class="docket">'
+    for i, (href, key, blurb, count) in enumerate([
+        ("cold-cases.html", "cold_cases",
+         "Every question nobody answered, and every loop still spinning.",
+         "%d items" % (stats["questions"] + stats["loops"])),
+        ("record.html", "record", "All the dinners, in the order they happened.",
+         "%d nights" % len(dinners)),
+        ("canon.html", "canon", "Claims asserted confidently, verified never.",
+         "%d claims" % stats["theories"]),
+        ("quotable.html", "quotable", "Pull a line at random from the transcript.",
+         "%d lines" % nq),
+    ]):
+        body += ('<a class="doc" href="%s"><span class="num">%02d</span>'
+                 '<span><span class="v">%s</span><br><span class="k">%s</span></span>'
+                 '<span class="d">%s</span></a>') % (
+            href, i + 1, e(sec[key]["title"]), e(blurb), e(count))
+    body += "</div>"
+
+    return page(cfg, cfg["title"], body, "index")
+
+
+def masthead(cfg, key, stats):
+    s = cfg["sections"][key]
+    return """
+<header class="mast">
+  <div class="kicker">%s</div>
+  <h1 class="title">%s</h1>
+  <p class="dek">%s</p>
+</header>
+""" % (e(s["kicker"]), e(s["title"]), e(s["dek"].format(**stats)))
+
+
+def build_record(cfg, dinners, stats):
+    body = masthead(cfg, "record", stats) + '<div class="docket">'
+    for i, d in enumerate(dinners):
+        kind = ('<span class="k">%s</span>' % e(d["kind"])) if d.get("kind") else ""
+        body += """  <a class="doc" href="dinners/%s.html">
+    <span class="num">%s</span>
+    <span><span class="v">%s</span><br>%s
+      <span class="tally">%d lines &middot; %d unanswered &middot; %d claims</span></span>
+    <span class="d">%s</span>
+  </a>
+""" % (e(d["slug"]), roman(i), e(d["venue"]), kind, len(d["quotes"]),
+       len(d["questions"]), len(d["theories"]), datestamp(d["date"]))
+    return page(cfg, cfg["sections"]["record"]["title"] + suffix(cfg), body + "</div>", "record")
+
+
+def anchor_id(prefix, text):
+    """Stable per-item id: survives reordering, changes only if the text does."""
+    digest = hashlib.sha1(text.strip().encode("utf-8")).hexdigest()[:8]
+    return "%s-%s" % (prefix, digest)
+
+
+def permalink(item_id, depth=0, page_name=""):
+    """Anchor + copy-link control rendered inside a list item."""
+    target = "%s%s#%s" % ("../" * depth, page_name, item_id)
+    return (' <a class="plink" href="%s" aria-label="Link to this item"'
+            ' title="Link to this item">#</a>') % e(target)
+
+
+def evidence_list(dinners, key, cls, depth=0, page_name="", prefix=None):
+    up = "../" * depth
+    rows = ""
+    for d, item in real_items(dinners, key):
+        item_id = anchor_id(prefix or key[:1], item)
+        rows += (
+            '  <li id="{id}">{text}{link}<span class="src">'
+            '<a href="{up}dinners/{slug}.html">{venue}</a> &middot; {date}</span></li>\n'
+        ).format(
+            id=e(item_id),
+            text=e(item),
+            link=permalink(item_id, depth, page_name),
+            up=up,
+            slug=e(d["slug"]),
+            venue=e(d["venue"]),
+            date=datestamp(d["date"]),
+        )
+    if not rows:
+        return '<p class="quiet">Nothing on record.</p>'
+    return '<ul class="evid %s">\n%s</ul>' % (cls, rows)
+
+
+def build_cold(cfg, dinners, stats):
+    body = masthead(cfg, "cold_cases", stats)
+    body += ('<h2 class="sec">Unanswered questions</h2>'
+             '<p class="sec-note">Raised at the table. Never resolved.</p><hr class="rule">')
+    body += evidence_list(dinners, "questions", "", page_name="cold-cases.html", prefix="q")
+    body += ('<h2 class="sec">Open loops</h2>'
+             '<p class="sec-note">Still spinning. Possibly forever.</p><hr class="rule">')
+    body += evidence_list(dinners, "loops", "loop", page_name="cold-cases.html", prefix="l")
+    if any(True for _ in real_items(dinners, "promised")):
+        body += ('<h2 class="sec">Promised, pending</h2>'
+                 '<p class="sec-note">Things people said they would send.</p><hr class="rule">')
+        body += evidence_list(dinners, "promised", "quest",
+                              page_name="cold-cases.html", prefix="p")
+    return page(cfg, cfg["sections"]["cold_cases"]["title"] + suffix(cfg), body, "cold-cases")
+
+
+def build_canon(cfg, dinners, stats):
+    body = masthead(cfg, "canon", stats)
+    body += '<h2 class="sec">Entered into evidence</h2><hr class="rule">'
+    body += evidence_list(dinners, "theories", "claim", page_name="canon.html", prefix="c")
+    nsq = total(dinners, "sidequests")
+    if nsq:
+        body += ('<h2 class="sec">Side quests</h2>'
+                 '<p class="sec-note">%d digressions that took over the table.</p>'
+                 '<hr class="rule">') % nsq
+        body += evidence_list(dinners, "sidequests", "quest",
+                              page_name="canon.html", prefix="s")
+    return page(cfg, cfg["sections"]["canon"]["title"] + suffix(cfg), body, "canon")
+
+
+def build_quotable(cfg, dinners, stats):
+    pool = [{"t": q["text"], "a": q["attrib"], "v": d["venue"],
+             "d": datestamp(d["date"]), "s": d["slug"],
+             "id": anchor_id("x", q["text"])}
+            for d in dinners for q in d["quotes"]]
+
+    body = masthead(cfg, "quotable", stats)
+    if not pool:
+        return page(cfg, cfg["sections"]["quotable"]["title"] + suffix(cfg),
+                    body + '<p class="quiet">No lines on record.</p>', "quotable")
+
+    body += '<div id="slot"></div><button class="btn" id="again">Pull another line</button>'
+    body += '<h2 class="sec">The complete set</h2><hr class="rule"><ul class="evid quest">'
+    for p in pool:
+        gloss = " <em>(%s)</em>" % e(p["a"]) if p["a"] else ""
+        body += (
+            '<li id="{id}">&ldquo;{text}&rdquo;{gloss}{link}<span class="src">'
+            '<a href="dinners/{slug}.html">{venue}</a> &middot; {date}</span></li>'
+        ).format(
+            id=e(p["id"]),
+            text=e(p["t"]),
+            gloss=gloss,
+            link=permalink(p["id"], 0, "quotable.html"),
+            slug=e(p["s"]),
+            venue=e(p["v"]),
+            date=p["d"],
+        )
+    body += "</ul>"
+
+    body += """
+<script>
+var Q = %s, last = -1, syncing = false;
+
+function show(i, setHash){
+  last = i;
+  var q = Q[i], slot = document.getElementById('slot');
+  slot.textContent = '';
+  var card = document.createElement('div');
+  card.className = 'exhibit';
+  card.style.width = '100%%';
+  var p = document.createElement('p');
+  p.className = 'q';
+  p.textContent = '\\u201c' + q.t + '\\u201d';
+  card.appendChild(p);
+  if (q.a) {
+    var g = document.createElement('div');
+    g.className = 'gloss'; g.textContent = q.a; card.appendChild(g);
+  }
+  var s = document.createElement('div');
+  s.className = 'src';
+  s.textContent = q.v + ' \\u00b7 ' + q.d + ' \\u00b7 ';
+  var link = document.createElement('a');
+  link.href = '#' + q.id;
+  link.textContent = 'link to this line';
+  s.appendChild(link);
+  card.appendChild(s);
+  slot.appendChild(card);
+  // Assigning location.hash (not replaceState) so :target follows the card and
+  // the previously linked row stops being highlighted. The scroll position is
+  // restored because the shuffle button is what the reader is looking at.
+  if (setHash && location.hash !== '#' + q.id) {
+    var x = window.pageXOffset, y = window.pageYOffset;
+    syncing = true;
+    location.hash = q.id;
+    window.scrollTo(x, y);
+  }
+}
+
+function pull(){
+  var i = Math.floor(Math.random()*Q.length);
+  if (Q.length > 1) { while (i === last) i = Math.floor(Math.random()*Q.length); }
+  show(i, true);
+}
+
+function fromHash(){
+  var h = location.hash.replace(/^#/, '');
+  if (!h) return -1;
+  for (var i = 0; i < Q.length; i++) { if (Q[i].id === h) return i; }
+  return -1;
+}
+
+document.getElementById('again').addEventListener('click', pull);
+
+var start = fromHash();
+show(start >= 0 ? start : Math.floor(Math.random()*Q.length), false);
+
+window.addEventListener('hashchange', function(){
+  if (syncing) { syncing = false; return; }
+  var i = fromHash();
+  if (i >= 0) show(i, false);
+});
+</script>
+""" % json.dumps(pool, ensure_ascii=False)
+    return page(cfg, cfg["sections"]["quotable"]["title"] + suffix(cfg), body, "quotable")
+
+
+def block(label, items, cls="plain", note=None, empty=False):
+    if not items:
+        return ""
+    out = '<h2 class="sec">%s</h2>' % e(label)
+    if note:
+        out += '<p class="sec-note">%s</p>' % e(note)
+    out += '<hr class="rule">'
+    if empty:
+        return out + '<p class="quiet">%s</p>' % e(items[0])
+    if cls == "plain":
+        return out + '<ul class="plain">%s</ul>' % "".join("<li>%s</li>" % e(i) for i in items)
+    return out + '<ul class="evid %s">%s</ul>' % (cls, "".join("<li>%s</li>" % e(i) for i in items))
+
+
+def build_dinner(cfg, dinners, i):
+    d = dinners[i]
+    prev = dinners[i - 1] if i > 0 else None
+    nxt = dinners[i + 1] if i < len(dinners) - 1 else None
+
+    sub = " &middot; ".join(filter(None, [
+        e(d["kind"]) if d.get("kind") else "",
+        datestamp(d["date"]),
+        "with " + e(d["companion"]) if d.get("companion") else "",
+    ]))
+
+    body = """
+<header class="dinner-head">
+  <div class="num">Sitting %s of %d</div>
+  <h1>%s</h1>
+  <p class="sub">%s</p>
+</header>
+<div class="mast-meta">
+  <span><b>%d</b> lines</span><span><b>%d</b> unanswered</span>
+  <span><b>%d</b> claims</span><span><b>%d</b> open loops</span>
+</div>
+""" % (roman(i), len(dinners), e(d["venue"]), sub, len(d["quotes"]),
+       len(d["questions"]), len(d["theories"]), len(d["loops"]))
+
+    if d["setting"]:
+        body += '<h2 class="sec">Setting and vibe</h2><hr class="rule">'
+        body += "".join('<p class="setting">%s</p>' % e(s) for s in d["setting"])
+
+    if d["quotes"]:
+        body += ('<h2 class="sec">Exhibits</h2>'
+                 '<p class="sec-note">Lines entered into the record.</p><hr class="rule">')
+        for q in d["quotes"]:
+            gloss = '<div class="gloss">%s</div>' % e(q["attrib"]) if q["attrib"] else ""
+            qid = anchor_id("x", q["text"])
+            body += (
+                '<div class="exhibit" id="{id}"><p class="q">&ldquo;{text}&rdquo;'
+                '<a class="plink" href="#{id}" aria-label="Link to this line"'
+                ' title="Link to this line">#</a></p>{gloss}</div>'
+            ).format(id=e(qid), text=e(q["text"]), gloss=gloss)
+
+    body += block("Main conversation threads", d["threads"])
+    body += block("Stories started", d["stories"])
+    body += block("Theories and claims", d["theories"], "claim")
+    body += block("Side quests", d["sidequests"], "quest")
+
+    if d["undercurrent"]:
+        body += '<h2 class="sec">Emotional undercurrents</h2><hr class="rule">'
+        body += "".join('<div class="undercurrent">%s</div>' % e(u) for u in d["undercurrent"])
+
+    body += block("Unanswered questions", d["questions"], "")
+    body += block("Promised to send", d["promised"], "quest", empty=d.get("promised_empty"))
+    body += block("Open loops", d["loops"], "loop")
+    body += block("Decisions or plans", d["decisions"], empty=d.get("decisions_empty"))
+    body += block("Next dinner", d["next"], empty=d.get("next_empty"))
+
+    for heading, items in (d.get("extra") or {}).items():
+        body += block(heading, items)
+
+    if d["transcript"]:
+        body += ('<p style="margin-top:34px"><a class="mono" style="font-size:.68rem;'
+                 'letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" '
+                 'href="%s">Full transcript &rarr;</a></p>') % e(d["transcript"])
+
+    body += '<div class="pager">'
+    body += ('<a href="%s.html">&larr; %s</a>' % (e(prev["slug"]), e(prev["venue"])) if prev
+             else '<a href="../record.html">&larr; The Record</a>')
+    body += ('<a href="%s.html">%s &rarr;</a>' % (e(nxt["slug"]), e(nxt["venue"])) if nxt
+             else '<a href="../cold-cases.html">Cold Cases &rarr;</a>')
+    body += "</div>"
+
+    return page(cfg, d["venue"] + suffix(cfg), body, "record", depth=1)
+
+
+# ---------------------------------------------------------------- main
+
+def main():
+    ap = argparse.ArgumentParser(description="Build a case-file site from dinner notes.")
+    ap.add_argument("trip", help="path to the trip folder (contains trip.json)")
+    ap.add_argument("--check", action="store_true",
+                    help="parse and report without writing any files")
+    args = ap.parse_args()
+
+    trip_dir = os.path.abspath(args.trip.rstrip("/"))
+    if not os.path.isdir(trip_dir):
+        sys.exit("not a directory: %s" % trip_dir)
+
+    raw_cfg, dinners = load_trip(trip_dir)
+    if not dinners:
+        sys.exit("no notes found in %s" % trip_dir)
+    cfg = merge(DEFAULTS, raw_cfg)
+
+    stats = {
+        "questions": total(dinners, "questions"),
+        "loops": total(dinners, "loops"),
+        "theories": total(dinners, "theories"),
+        "quotes": total(dinners, "quotes"),
+        "dinners": len(dinners),
+    }
+    threads = find_threads(dinners, cfg.get("threads"), cfg.get("thread_min_sittings", 2))
+
+    print("%s -- %d dinners" % (cfg["title"], len(dinners)))
+    for d in dinners:
+        missing = [k for k in ("setting", "quotes", "questions") if not d.get(k)]
+        flag = "   <-- empty: " + ",".join(missing) if missing else ""
+        print("  %-14s %-22s %s  q=%-3d ?=%-3d%s" % (
+            d["slug"], d["venue"][:22], d["date"] or "no-date",
+            len(d["quotes"]), len(d["questions"]), flag))
+    print("  totals: %(quotes)d lines, %(questions)d unanswered, "
+          "%(loops)d loops, %(theories)d claims" % stats)
+    if threads:
+        print("  threads: " + ", ".join("%s (%d)" % (l, len(h)) for l, h in threads))
+    for label in (cfg.get("threads") or {}):
+        if label not in [l for l, _ in threads]:
+            print("  note: thread %r below the %d-sitting cutoff" % (
+                label, cfg.get("thread_min_sittings", 2)))
+
+    if args.check:
+        print("\n--check: nothing written")
+        return
+
+    data_dir = os.path.join(trip_dir, "_data")
+    os.makedirs(data_dir, exist_ok=True)
+    with open(os.path.join(data_dir, "dinners.json"), "w") as f:
+        json.dump(dinners, f, indent=2, ensure_ascii=False)
+
+    pages = [
+        ("index.html", build_home(cfg, dinners, threads)),
+        ("record.html", build_record(cfg, dinners, stats)),
+        ("cold-cases.html", build_cold(cfg, dinners, stats)),
+        ("canon.html", build_canon(cfg, dinners, stats)),
+        ("quotable.html", build_quotable(cfg, dinners, stats)),
+    ]
+    os.makedirs(os.path.join(trip_dir, "dinners"), exist_ok=True)
+    for i, d in enumerate(dinners):
+        pages.append((os.path.join("dinners", d["slug"] + ".html"),
+                      build_dinner(cfg, dinners, i)))
+
+    for name, content in pages:
+        with open(os.path.join(trip_dir, name), "w") as f:
+            f.write(content)
+
+    print("\nwrote %d pages to %s" % (len(pages), trip_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/_tools/papers/parse.py
+++ b/_tools/papers/parse.py
@@ -1,0 +1,371 @@
+"""Parse Granola-style dinner notes into structured records.
+
+Granola exports a stable set of `### ` sections per note. Everything here keys
+off those headings, so a new trip needs no code changes -- only a trip.json.
+
+Sections are read into `SECTION_MAP` keys; any heading not in the map is kept
+under its own lowercased name so unexpected sections are never silently lost.
+Dates parse from the `Sun, 09 Aug 26` byline; `companion` comes from the same
+line after the middot separator.
+"""
+import json
+import os
+import re
+
+SECTION_MAP = {
+    "attendees": "attendees",
+    "setting and vibe": "setting",
+    "main conversation threads": "threads",
+    "stories started": "stories",
+    "best lines and bits": "quotes",
+    "theories and claims": "theories",
+    "side quests": "sidequests",
+    "emotional undercurrents": "undercurrent",
+    "unanswered questions": "questions",
+    "things people promised to send": "promised",
+    "open loops": "loops",
+    "decisions or plans": "decisions",
+    "next dinner": "next",
+}
+
+LIST_FIELDS = [
+    "attendees", "setting", "threads", "stories", "theories", "sidequests",
+    "undercurrent", "questions", "promised", "loops", "decisions", "next",
+]
+
+MONTHS = {
+    "jan": "01", "feb": "02", "mar": "03", "apr": "04", "may": "05", "jun": "06",
+    "jul": "07", "aug": "08", "sep": "09", "oct": "10", "nov": "11", "dec": "12",
+}
+
+DAY_RE = r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)"
+NOTHING_RE = re.compile(
+    r"^(no |nothing |none\b)", re.I
+)
+
+
+def dedupe(text):
+    """Some exports paste the same note repeatedly; keep one copy.
+
+    Splits on the H1 and collapses only when every segment is identical, so a
+    file that genuinely concatenates different notes is left alone.
+    """
+    lines = text.split("\n")
+    head = lines[0].strip()
+    if not head.startswith("# "):
+        return text
+    segs = [s for s in text.split(head) if s.strip()]
+    if len(segs) > 1 and len(set(s.strip() for s in segs)) == 1:
+        return head + segs[0]
+    return text
+
+
+def parse_byline(line):
+    """`Sun, 09 Aug 26 - Name` -> (iso_date, companion)."""
+    date, companion = "", ""
+    m = re.match(
+        r"^%s,?\s+(\d{1,2})\s+([A-Za-z]{3})[a-z]*\.?\s+(\d{2,4})" % DAY_RE, line
+    )
+    if m:
+        d, mon, y = m.groups()
+        year = y if len(y) == 4 else "20" + y
+        date = "%s-%s-%02d" % (year, MONTHS.get(mon.lower(), "01"), int(d))
+    parts = [p.strip() for p in re.split(r"[·|]", line)]
+    if len(parts) > 1:
+        companion = parts[1]
+    return date, companion
+
+
+def split_sections(raw):
+    """Return {heading: [raw lines]} for every `### ` block."""
+    out, current = {}, None
+    for ln in raw.split("\n"):
+        m = re.match(r"^#{2,4}\s+(.*)$", ln)
+        if m:
+            current = m.group(1).strip()
+            out.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        if ln.strip().startswith("Chat with meeting transcript"):
+            continue
+        out[current].append(ln)
+    return out
+
+
+def collect(lines):
+    """Flatten a section into a list of entries, bullets first then prose.
+
+    Sub-headings inside a section (Granola sometimes emits bold or bare-line
+    group labels) are folded in as plain entries rather than dropped.
+    """
+    bullets, prose = [], []
+    for ln in lines:
+        s = ln.strip()
+        if not s or s == "---":
+            continue
+        if s.startswith(("- ", "* ")):
+            bullets.append(s[2:].strip())
+        elif s.startswith(("+ ",)):
+            bullets.append(s[2:].strip())
+        elif len(s) > 3:
+            prose.append(re.sub(r"^\*+|\*+$", "", s).strip())
+    return bullets + prose
+
+
+CLOSERS = {"“": "”", '"': '"', "‘": "’", "'": "'"}
+
+
+def clean_quote(q):
+    """Split a `"line" (attribution)` bullet into (text, attribution).
+
+    Matches the closing delimiter to the opening one and scans from the END of
+    the line, so apostrophes inside the quote are never mistaken for the close.
+    An unbalanced line degrades to the whole string with no attribution.
+    """
+    q = q.strip().lstrip("-*+").strip()
+    if not q:
+        return "", ""
+
+    # `Speaker, on the thing: "line"` -> keep the lead-in as the attribution.
+    lead = re.match(r'^([^“"]{2,60}?):\s*([“"].*)$', q, re.S)
+    if lead:
+        text, inner = clean_quote(lead.group(2))
+        return text, inner or lead.group(1).strip()
+
+    opener = q[0]
+    if opener in CLOSERS:
+        closer = CLOSERS[opener]
+        # Prefer a closer whose remainder is empty or a single parenthetical --
+        # attributions may themselves contain quotes, so scanning from the end
+        # would swallow the whole line.
+        best = -1
+        for i in range(1, len(q)):
+            if q[i] != closer:
+                continue
+            rest = q[i + 1:].strip()
+            if not rest or re.fullmatch(r"\(.*\)", rest, re.S):
+                best = i
+                break
+            if best < 0:
+                best = i
+        if best > 0:
+            return q[1:best].strip(), q[best + 1:].strip().strip("()").strip(" —-")
+        return q[1:].strip(), ""
+
+    # Unquoted bullet: peel a trailing parenthetical as the attribution.
+    m = re.match(r"^(.*?)\s*\(([^()]*)\)\s*$", q)
+    if m:
+        return m.group(1).strip(), m.group(2).strip()
+    return q, ""
+
+
+def is_nothing(items):
+    """True when a section only says some variant of 'nothing happened'."""
+    return len(items) == 1 and bool(NOTHING_RE.match(items[0]))
+
+
+def title_case_venue(slug, title):
+    """Prefer the note's own H1; fall back to a tidied slug."""
+    t = (title or "").strip()
+    if t and t.lower() != slug.lower():
+        return t if not t.islower() else t.title()
+    return slug.replace("_", " ").title()
+
+
+def parse_note(path):
+    raw = dedupe(open(path).read())
+    lines = raw.split("\n")
+    slug = os.path.splitext(os.path.basename(path))[0]
+
+    title = lines[0].lstrip("#").strip() if lines[0].startswith("#") else slug
+    byline, date, companion = "", "", ""
+    for ln in lines[1:8]:
+        if re.match(r"^%s," % DAY_RE, ln.strip()):
+            byline = ln.strip()
+            date, companion = parse_byline(byline)
+            break
+
+    sections = split_sections(raw)
+    rec = {
+        "slug": slug,
+        "title": title,
+        "venue": title_case_venue(slug, title),
+        "byline": byline,
+        "date": date,
+        "companion": companion,
+        "extra": {},
+    }
+    for f in LIST_FIELDS:
+        rec[f] = []
+    rec["quotes"] = []
+
+    for heading, body in sections.items():
+        items = collect(body)
+        key = SECTION_MAP.get(heading.strip().lower())
+        if key == "quotes":
+            for b in items:
+                text, attrib = clean_quote(b)
+                if text:
+                    rec["quotes"].append({"text": text, "attrib": attrib})
+        elif key:
+            rec[key] = items
+        elif items:
+            rec["extra"][heading] = items
+
+    m = re.search(r"(https://notes\.granola\.ai/\S+)", raw)
+    rec["transcript"] = m.group(1).rstrip("#") if m else ""
+
+    for f in ("decisions", "next", "promised"):
+        rec[f + "_empty"] = is_nothing(rec[f])
+
+    return rec
+
+
+def redact_text(s, pairs):
+    """Replace each configured name with its stand-in.
+
+    Longest patterns run first so a full name is handled before its first name,
+    and matching is word-bounded and case-sensitive to avoid mangling ordinary
+    words that happen to contain a name.
+    """
+    for rx, repl in pairs:
+        s = rx.sub(repl, s)
+    # An initial ending in "." next to sentence punctuation, and a role stand-in
+    # landing after the noun it replaces, both read as typos.
+    s = re.sub(r"\.\.(?=\s|$)", ".", s)
+    s = re.sub(r"\b([Tt]he)\s+(\w+)\s+the\s+\2\b", r"\1 \2", s)
+    s = re.sub(r"\b([Tt]he)\s+the\b", r"\1", s)
+    return s
+
+
+def compile_redactions(names):
+    """Build (regex, replacement) pairs, longest name first."""
+    pairs = []
+    for name in sorted(names or {}, key=len, reverse=True):
+        pairs.append((re.compile(r"\b%s\b" % re.escape(name)), names[name]))
+    return pairs
+
+
+def suppress(rec, patterns):
+    """Drop individual entries matching any pattern, section by section.
+
+    Lets a single sensitive line be withheld without losing the section around
+    it. Patterns are case-insensitive substrings or regexes.
+    """
+    if not patterns:
+        return rec
+    rxs = [re.compile(p, re.I) for p in patterns]
+    hit = lambda s: any(r.search(s) for r in rxs)
+    for f in LIST_FIELDS:
+        rec[f] = [x for x in rec.get(f) or [] if not hit(x)]
+    rec["quotes"] = [q for q in rec.get("quotes") or []
+                     if not hit(q["text"]) and not hit(q["attrib"])]
+    rec["extra"] = {k: [v for v in vals if not hit(v)]
+                    for k, vals in (rec.get("extra") or {}).items()}
+    rec["extra"] = {k: v for k, v in rec["extra"].items() if v}
+    return rec
+
+
+def redact_record(rec, pairs, drop):
+    """Apply name redaction and drop suppressed sections from one dinner."""
+    for key in drop or []:
+        if key in rec:
+            rec[key] = []
+            rec[key + "_empty"] = False
+    if not pairs:
+        return rec
+    for f in LIST_FIELDS:
+        rec[f] = [redact_text(x, pairs) for x in rec.get(f) or []]
+    rec["quotes"] = [
+        {"text": redact_text(q["text"], pairs),
+         "attrib": redact_text(q["attrib"], pairs)}
+        for q in rec.get("quotes") or []
+    ]
+    rec["extra"] = {
+        redact_text(k, pairs): [redact_text(v, pairs) for v in vals]
+        for k, vals in (rec.get("extra") or {}).items()
+    }
+    for f in ("title", "venue", "companion", "byline"):
+        rec[f] = redact_text(rec.get(f) or "", pairs)
+    return rec
+
+
+def apply_aliases(dinners, aliases):
+    """Normalize companion spellings, e.g. a run-together Granola handle."""
+    if not aliases:
+        return
+    lookup = {}
+    for canonical, variants in aliases.items():
+        lookup[re.sub(r"[^a-z]", "", canonical.lower())] = canonical
+        for v in variants:
+            lookup[re.sub(r"[^a-z]", "", v.lower())] = canonical
+    for d in dinners:
+        key = re.sub(r"[^a-z]", "", (d.get("companion") or "").lower())
+        if key in lookup:
+            d["companion"] = lookup[key]
+
+
+def deep_merge(base, over):
+    out = dict(base)
+    for k, v in (over or {}).items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        elif isinstance(v, list) and isinstance(out.get(k), list):
+            out[k] = out[k] + v
+        else:
+            out[k] = v
+    return out
+
+
+def load_trip(trip_dir):
+    """Read trip.json (+ optional trip.private.json) and return (cfg, dinners).
+
+    `trip.private.json` holds anything that must not be published -- real names
+    and suppression patterns are a decoder ring for the redacted output, so they
+    live in a gitignored sibling and are merged over the public config.
+    """
+    cfg_path = os.path.join(trip_dir, "trip.json")
+    cfg = json.load(open(cfg_path)) if os.path.exists(cfg_path) else {}
+
+    priv_path = os.path.join(trip_dir, "trip.private.json")
+    if os.path.exists(priv_path):
+        cfg = deep_merge(cfg, json.load(open(priv_path)))
+
+    notes_dir = os.path.join(trip_dir, cfg.get("notes_dir", "granola_notes"))
+    if not os.path.isdir(notes_dir):
+        raise SystemExit("no notes directory: %s" % notes_dir)
+
+    found = sorted(f for f in os.listdir(notes_dir) if f.endswith(".md"))
+    order = cfg.get("order") or []
+    slugs = [s for s in order if s + ".md" in found]
+    slugs += [os.path.splitext(f)[0] for f in found
+              if os.path.splitext(f)[0] not in slugs]
+
+    dinners = [parse_note(os.path.join(notes_dir, s + ".md")) for s in slugs]
+
+    meta = cfg.get("venues", {})
+    for d in dinners:
+        over = meta.get(d["slug"], {})
+        d["venue"] = over.get("name", d["venue"])
+        d["kind"] = over.get("kind", "")
+        if over.get("date"):
+            d["date"] = over["date"]
+
+    apply_aliases(dinners, cfg.get("companion_aliases"))
+
+    # Suppression runs on the original text; redaction would rewrite the very
+    # names the patterns match on.
+    suppressed = cfg.get("suppress") or []
+    if suppressed:
+        dinners = [suppress(d, suppressed) for d in dinners]
+
+    pairs = compile_redactions(cfg.get("redact_names"))
+    drop = cfg.get("drop_sections") or []
+    if pairs or drop:
+        dinners = [redact_record(d, pairs, drop) for d in dinners]
+
+    if not cfg.get("order"):
+        dinners.sort(key=lambda d: (d["date"] or "9999", d["slug"]))
+
+    return cfg, dinners

--- a/_tools/papers/theme.py
+++ b/_tools/papers/theme.py
@@ -1,0 +1,241 @@
+"""Page chrome and stylesheet for generated papers sites.
+
+`CSS` is emitted inline so a generated trip folder is fully self-contained and
+needs no asset paths. Palettes respond to `prefers-color-scheme` and to an
+explicit `data-theme` attribute, which the footer toggle persists.
+"""
+
+CSS = """
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\\21bb"}
+ul.evid.claim li:before{content:"\\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+"""
+
+THEME_JS = """
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+"""
+
+TABS = [
+    ("index.html", "The Case", "index"),
+    ("record.html", "The Record", "record"),
+    ("cold-cases.html", "Cold Cases", "cold-cases"),
+    ("canon.html", "Canon", "canon"),
+    ("quotable.html", "Quotable", "quotable"),
+]

--- a/the_wilmington_papers/canon.html
+++ b/the_wilmington_papers/canon.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Canon - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/canon.html
+++ b/the_wilmington_papers/canon.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Canon - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html" aria-current="page">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="mast">
+  <div class="kicker">Section III - the record of claims</div>
+  <h1 class="title">Canon</h1>
+  <p class="dek">56 assertions made at the table with total confidence and zero verification. Presented here as fact, because that is how they were said.</p>
+</header>
+<h2 class="sec">Entered into evidence</h2><hr class="rule"><ul class="evid claim">
+  <li id="c-b25df5ec">Terrazzo originated in 15th century Venice, workers pressed marble scraps into clay and sealed the surface with goat’s milk <a class="plink" href="canon.html#c-b25df5ec" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-4e47edb8">There is a specific Italian-American trades term for leftover building materials, possibly with mob connections, that B. could not retrieve <a class="plink" href="canon.html#c-4e47edb8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-c224f0f5">The wheelchair slap would only be justifiable if someone made a cruel joke about a very recently deceased person close to the slapper <a class="plink" href="canon.html#c-c224f0f5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-ef6f64c0">Istanbul cymbals are currently more coveted than Zildjian, Paiste, and Sabian <a class="plink" href="canon.html#c-ef6f64c0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-07ea7e51">Hand hammering gives each cymbal a unique character and is part of what makes them worth buying <a class="plink" href="canon.html#c-07ea7e51" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-262a102a">Turkey is still the gold standard for cymbal manufacturing <a class="plink" href="canon.html#c-262a102a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-9eb14945">The reservation-only policy is a gatekeeper move, not a capacity issue. The restaurant had many empty tables. <a class="plink" href="canon.html#c-9eb14945" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-99464df3">The wheelchair woman may have provoked the slapper. “They should have known the hit rate on a wheelchair person.” <a class="plink" href="canon.html#c-99464df3" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-72f09be5">The bidet in a public Wilmington restaurant represents a genuine cultural leap. B. has been in public restrooms on multiple continents and has never seen one offered. <a class="plink" href="canon.html#c-72f09be5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-723c5997">Greek music is more Eastern and Byzantine than Italian. “A little more poly.” Confident but unverified. <a class="plink" href="canon.html#c-723c5997" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-74740578">The OnlyFans birthday drop strategy is marketing genius. The legal technicality around photo timing was raised and then abandoned. <a class="plink" href="canon.html#c-74740578" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-9d850b62">“Nona” might be Polish, not Italian. Disputed. Unresolved. <a class="plink" href="canon.html#c-9d850b62" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="c-cfbf9d7f">New York and LA are the only true S-tier US cities; everything else is A-tier at best <a class="plink" href="canon.html#c-cfbf9d7f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-5c7cdf6f">Chicago earns S-tier partly because of the Bean, the Bulls 90s lore, two baseball teams, Northwestern, and Lake Michigan <a class="plink" href="canon.html#c-5c7cdf6f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-63403dfa">Lake Michigan is the lake Chicago sits on (stated with some uncertainty) <a class="plink" href="canon.html#c-63403dfa" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-52c1390e">Mexico City might be S-tier within its own regional context but unclear on the world scale <a class="plink" href="canon.html#c-52c1390e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-07f8c8af">New Zealand is a continent called Oceana, so it has no S-tier cities by default <a class="plink" href="canon.html#c-07f8c8af" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-b8ee345d">The Hoggard valedictorian gamed the system by avoiding the IB program <a class="plink" href="canon.html#c-b8ee345d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-4bd687c7">Fancy restaurants give small portions so you don’t tire of the flavor before the next course <a class="plink" href="canon.html#c-4bd687c7" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-79ea2152">THC cocktails are a real and underdeveloped market opportunity, especially while the regulatory window is open <a class="plink" href="canon.html#c-79ea2152" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-3d81f2d8">Chobani makes oat milk, which is why the homemade cocktail got so frothy <a class="plink" href="canon.html#c-3d81f2d8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="c-fdc6335e">Grapefruit interacts badly with certain medications by affecting a “very specific mechanism”; Speaker B risked it anyway <a class="plink" href="canon.html#c-fdc6335e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-b13bed3b">The well-dressed people walking by were probably going to a show at the Thalian Theater; confirmed nothing was actually playing that night <a class="plink" href="canon.html#c-b13bed3b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-89707e79">Silk does not breathe, which makes the scarf the woman outside was wearing inexplicable <a class="plink" href="canon.html#c-89707e79" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-eeee9658">Chiropractors make great money: cash pay, no co-pays, multiple concurrent patients, plus an acupuncturist on staff <a class="plink" href="canon.html#c-eeee9658" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-8eed2c76">The Steely Dan name comes from a dildo reference; Speaker B claims he told B. this earlier that same day <a class="plink" href="canon.html#c-8eed2c76" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-48fa7094">Steely Dan only really toured on their first album <a class="plink" href="canon.html#c-48fa7094" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-87cfe0dc">The “70s Soft Rock Bottoms” Spotify playlist is responsible for three Steely Dan songs and an Atlanta Rhythm Section track in one sitting <a class="plink" href="canon.html#c-87cfe0dc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-78c06484">Parsley either cleanses the palate before eating or freshens breath after; nobody knew which, and it fades fast anyway <a class="plink" href="canon.html#c-78c06484" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-7e48058d">What they thought was parsley on the pork chop was actually cilantro <a class="plink" href="canon.html#c-7e48058d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="c-4560c135">ICP is from the Midwest but gives off West Virginia vibes. Someone insisted this tracks culturally even though it makes no geographic sense. <a class="plink" href="canon.html#c-4560c135" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-705a4c6f">Georgetown, D.C. has no subway stop because wealthy residents did not want it. Classist, not racist, per the speaker. <a class="plink" href="canon.html#c-705a4c6f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-2264ad6a">Cambridge probably has a parallel situation to Georgetown. <a class="plink" href="canon.html#c-2264ad6a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-53694e71">Autonomous vehicles will eventually turn roads into de facto train systems, making rail infrastructure redundant. <a class="plink" href="canon.html#c-53694e71" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-8a686f77">I-95 through the Baltimore corridor is always a disaster unless you roll through at 3am. <a class="plink" href="canon.html#c-8a686f77" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-a98fbebe">The World Cup “made a market from nothing” by banning cars and forcing everyone onto 10x-priced trains. <a class="plink" href="canon.html#c-a98fbebe" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-cd6c70a9">The government has been inept at infrastructure for 100 years and cannot catch up now. <a class="plink" href="canon.html#c-cd6c70a9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-49857edd">If Tesla goes under and “Enrons us,” there is nothing to show for the investment. <a class="plink" href="canon.html#c-49857edd" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-879e85c9">Eminent domain is now commonly used to favor affluent private developers over communities, not for schools or fire stations. <a class="plink" href="canon.html#c-879e85c9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-5ab0c5fb">The conversation ended with someone suggesting their shared politics amounted to advocating for a “classless, stateless experiment,” i.e., communism. <a class="plink" href="canon.html#c-5ab0c5fb" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-6f139577">A nonprofit bar structured as a church could avoid taxes, but getting IRS recognition upfront is a lot of work <a class="plink" href="canon.html#c-6f139577" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-851cd079">Easier to just infiltrate an existing struggling Lutheran church and flip the pews to face each other <a class="plink" href="canon.html#c-851cd079" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-ffbfaf2d">A dive bar making $1 per beer, 2 beers per hour per person, 10 customers: that’s $20/hour, barely minimum wage for one person <a class="plink" href="canon.html#c-ffbfaf2d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-95bedb9f">You need at least 4 to 5 staff to run a place like Banter <a class="plink" href="canon.html#c-95bedb9f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-8280b9ef">Hotel restaurants are either great or “a saltwater Applebee’s” <a class="plink" href="canon.html#c-8280b9ef" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-ea363a15">The ideal EPL team to support should be northern, rugged, and not one of the big London clubs <a class="plink" href="canon.html#c-ea363a15" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-e381c97d">Liverpool is probably the fisherman’s town equivalent, the “New England of England” <a class="plink" href="canon.html#c-e381c97d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-955ae7b9">Kurt Vile and the War on Drugs are both from Philly (someone was not sure, Detroit came up as a counter) <a class="plink" href="canon.html#c-955ae7b9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-8ab548a2">Jack White is from Detroit. Detroit Rock City confirmed. <a class="plink" href="canon.html#c-8ab548a2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-49ea78f2">Non-point source pollution theory applied to bad people: small bad actors outnumber big bad ones, so on aggregate there are more baddies <a class="plink" href="canon.html#c-49ea78f2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-24942251">“On aggregate” debated at length; concluded it means “in total, all things considered,” not averaging <a class="plink" href="canon.html#c-24942251" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-49a1ffdf">Popcorn ceilings with black mold cannot be rectified, must come out entirely <a class="plink" href="canon.html#c-49a1ffdf" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-81cdc59f">Truly old people have more tattoos because they were young when tattoos were a thing <a class="plink" href="canon.html#c-81cdc59f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-6ca9fd68">Military labs working on artificial viruses, possibly to get ahead of immunology threats, “but it’s gonna get out and we’re all gonna die from a super virus” <a class="plink" href="canon.html#c-6ca9fd68" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-59fb676c">The pizza delivery metric in D.C. as a predictor of imminent military action: “we’re about to bomb someone, there’s a lot of pizza” <a class="plink" href="canon.html#c-59fb676c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="c-ccc0e0f9">Certified forklift operators (CFOs) are a distinct and elite class <a class="plink" href="canon.html#c-ccc0e0f9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+</ul><h2 class="sec">Side quests</h2><p class="sec-note">31 digressions that took over the table.</p><hr class="rule"><ul class="evid quest">
+  <li id="s-c72a3fdb">CW&amp;T, a Brooklyn design house: came up because T.’s folding scissors are from there, and apparently so is B.’s brass pen that S. gave him <a class="plink" href="canon.html#s-c72a3fdb" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-1e7754af">The nearby dancer with the tequila in a plastic cup who was “twirling” and described as chiseled but slim: “We were observed. He had questions.” <a class="plink" href="canon.html#s-1e7754af" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-6895618e">T. almost brought folding scissors through TSA and was prepared to be very frustrated if they got confiscated <a class="plink" href="canon.html#s-6895618e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-97acd56c">The bidet: discovered in the bathroom mid-meal, became a recurring symbol of Wilmington’s unexpected cultural ambition. <a class="plink" href="canon.html#s-97acd56c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-1ad7cf95">The retired cop at 4 o’clock: a man at a nearby table had been watching the whole time. Identified as probably Irish, probably a retired cop, definitely noticing things. <a class="plink" href="canon.html#s-1ad7cf95" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-ff77ce76">The olive incident: B. launched an olive across the floor. A nearby diner witnessed the entire arc. Evidence was destroyed but the witness remained. <a class="plink" href="canon.html#s-ff77ce76" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-0f00f79f">The music: went from electronic to Latin to what sounded like an 80s brass section. Neither could identify it as definitively Greek. <a class="plink" href="canon.html#s-0f00f79f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-ed8eecc4">Binder clips: B. has been into binder clips lately. T. noticed. Neither wanted to make it a thing. It became a thing briefly anyway. <a class="plink" href="canon.html#s-ed8eecc4" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="s-bfd261e8">Long digression on whether the community pool can legally order members out during lightning; the answer at this pool was no, only “advise” <a class="plink" href="canon.html#s-bfd261e8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-528cdbce">Debate about whether a 3-second or 10-second lightning rule is correct <a class="plink" href="canon.html#s-528cdbce" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-74acc1a0">Granola being banned in 30-something states due to age verification requirements <a class="plink" href="canon.html#s-74acc1a0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-10a1ff06">Dodgeball (the movie) may or may not have been watched once or twice or three times the night before <a class="plink" href="canon.html#s-10a1ff06" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-4f5995e0">The mysterious family group at a nearby table: two girls, two boys, one woman without an apparent partner, formal dresses on a Monday <a class="plink" href="canon.html#s-4f5995e0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-7ad3d8e8">Bench seat complaint: B.’s feet don’t touch the floor <a class="plink" href="canon.html#s-7ad3d8e8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="s-04e3d7e5">Arrow symbols on the menu: turned out to indicate wine pairing options, not sourcing info <a class="plink" href="canon.html#s-04e3d7e5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="s-cdb433b0">The bell pepper in a dish: debated whether it was a shishito; Speaker B realized mid-conversation he was reading last night’s menu <a class="plink" href="canon.html#s-cdb433b0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="s-a3f6e998">Numbering students instead of learning their names: Speaker B considered piloting it in one class, then talked himself out of it <a class="plink" href="canon.html#s-a3f6e998" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="s-9f616240">The man in the all-white suit crossing the street: briefly became a Truman Show conspiracy, then a paranoia tangent <a class="plink" href="canon.html#s-9f616240" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="s-3e22db9c">Whether the woman outside was upset or just wearing a dress with a tie: unresolved <a class="plink" href="canon.html#s-3e22db9c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="s-bb86fa56">“Automaticity” or “automatissim”: one person kept trying to use this word, the other refused to accept it as real. Eventually resolved as “autonomy.” <a class="plink" href="canon.html#s-bb86fa56" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-82fa1753">Brown bag meeting explainer: someone had to leave for a work “brown bag.” The other person did not know what that meant. Full etymology provided. Concluded: it means bring your lunch, it signals informality. <a class="plink" href="canon.html#s-82fa1753" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-7279520f">The severance analogy for the teaching workday: eat lunch fast, take a piss, dissociate for four more hours, go home. <a class="plink" href="canon.html#s-7279520f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-cf609a9a">Deep dive into whether “banter” requires playfulness or just means casual back-and-forth, including whether it works as a literary device <a class="plink" href="canon.html#s-cf609a9a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-d2bf6c5b">Attempting to locate the hidden brass rabbit by deduction: not in the bathroom, not behind the bar, not under cushions, visible in plain sight, brass/golden/bronzy, about 10 inches, beard on it <a class="plink" href="canon.html#s-d2bf6c5b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-8283934c">Someone ordered what they thought would be a flowery pink drink called a White Wedding and got something very different. Accepted it without complaint. <a class="plink" href="canon.html#s-8283934c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-68a9e369">Brief detour into a YouTube ad that asked “would you hire a convicted sex offender?” which played immediately on TV at someone’s house <a class="plink" href="canon.html#s-68a9e369" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-1c2643af">Calculating max occupancy of the restaurant: 12 at tables, 12 at bar, 20 standing behind bar, arrived at roughly 44 to 80 depending on methodology. Became its own math exercise. <a class="plink" href="canon.html#s-1c2643af" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-470350ea">The sparkling water bottle origin: debated between Long Island, Hudson Valley, Catskills, and Mamaroneck. “Those are microscopic bubbles that almost hurt.” <a class="plink" href="canon.html#s-470350ea" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-66ec2bcc">The gun safe: attempted to crack it by feel, got to the third click, explained the full mechanism in detail. No success confirmed. <a class="plink" href="canon.html#s-66ec2bcc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-ed4c5e15">The camera moment: a nearby couple stared at the camera, one person thought they were being engaged, the other realized they were just looking past them at water bottles. Resolved awkwardly. <a class="plink" href="canon.html#s-ed4c5e15" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="s-7d8b9f2d">Forklift operator competitions on German television: witnessed in person, involved filling a glass with microscopic precision. Certified. <a class="plink" href="canon.html#s-7d8b9f2d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+</ul>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/cold-cases.html
+++ b/the_wilmington_papers/cold-cases.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Cold Cases - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html" aria-current="page">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="mast">
+  <div class="kicker">Section I - unresolved</div>
+  <h1 class="title">Cold Cases</h1>
+  <p class="dek">44 questions asked and never answered. 31 loops left open. No one is working on any of this.</p>
+</header>
+<h2 class="sec">Unanswered questions</h2><p class="sec-note">Raised at the table. Never resolved.</p><hr class="rule"><ul class="evid ">
+  <li id="q-36664868">What is the specific Italian-American trades term for scrap building materials? B. said “that’s gonna haunt me now.” <a class="plink" href="cold-cases.html#q-36664868" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-9600f6eb">What actually preceded the wheelchair slap? “That’s what we all want to know.” <a class="plink" href="cold-cases.html#q-9600f6eb" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-4016af71">Which Law and Order episode is “Confession” exactly, and was the cop dirty or just grieving? <a class="plink" href="cold-cases.html#q-4016af71" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-ff9e04b7">What was the name of the bartender or attendee someone was trying to remember? Landed on “A.M.” but with low confidence. <a class="plink" href="cold-cases.html#q-ff9e04b7" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-ea06b205">Can you be Greek for Greek? (Resolved: yes, in all permutations.) <a class="plink" href="cold-cases.html#q-ea06b205" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-74f73472">Is “Greco” the giver or the receiver? (Unresolved. The Greeks preceded the Romans chronologically, which was considered relevant but not decisive.) <a class="plink" href="cold-cases.html#q-74f73472" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-8b979874">Who was the OnlyFans birthday girl? <a class="plink" href="cold-cases.html#q-8b979874" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-cc8683f6">Was there actually a wheelchair? B. second-guessed his own memory. <a class="plink" href="cold-cases.html#q-cc8683f6" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-c791e5fc">Is “Nona” Polish or Italian? <a class="plink" href="cold-cases.html#q-c791e5fc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-78d9404f">What actually started the fight outside? <a class="plink" href="cold-cases.html#q-78d9404f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-7d4bd61b">What year did Step Brothers come out? (Someone said 2006. Unverified.) <a class="plink" href="cold-cases.html#q-7d4bd61b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="q-1df83769">What exactly is the server’s deal? <a class="plink" href="cold-cases.html#q-1df83769" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-20dcb252">Was the valedictorian actually Jewish, or just quoting Kanye at Jews? <a class="plink" href="cold-cases.html#q-20dcb252" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-3c7be083">Did the wheelchair slapping make it onto social media? <a class="plink" href="cold-cases.html#q-3c7be083" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-b3304d22">Which lake is Chicago actually on, Michigan or Superior? <a class="plink" href="cold-cases.html#q-b3304d22" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-506707dd">Who were the formally dressed people at the nearby table and what was the occasion? <a class="plink" href="cold-cases.html#q-506707dd" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-b5ea12c8">Is the dodgeball quote a real callback or did someone just independently say it? <a class="plink" href="cold-cases.html#q-b5ea12c8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-8fa73399">What was the fourth ingredient in the homemade cocktail before the creamer reveal? <a class="plink" href="cold-cases.html#q-8fa73399" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="q-d404614a">What does the arrow symbol on the menu actually indicate for the oysters specifically? <a class="plink" href="cold-cases.html#q-d404614a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-ba3daa57">What was the bell pepper in the dish, really? Shishito? Stuffed pepper? Something else? <a class="plink" href="cold-cases.html#q-ba3daa57" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-db6935d9">Is the woman outside upset or just wearing a wrap dress? <a class="plink" href="cold-cases.html#q-db6935d9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-81f4eea9">What is the actual success rate of the escape rooms downtown? <a class="plink" href="cold-cases.html#q-81f4eea9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-cf7e76fa">Which Steely Dan song came before “Reeling in the Years”? <a class="plink" href="cold-cases.html#q-cf7e76fa" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-26b5b659">Does silk actually breathe or not? <a class="plink" href="cold-cases.html#q-26b5b659" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-0bee31b6">Who is the man in the all-white suit and where was he going? <a class="plink" href="cold-cases.html#q-0bee31b6" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-a1af8696">What was playing at the Thalian Theater, if anything? <a class="plink" href="cold-cases.html#q-a1af8696" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="q-034452c6">Is ICP from the Midwest, West Virginia, or LA? Someone refused to look it up. <a class="plink" href="cold-cases.html#q-034452c6" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-ed00916f">Did ICP actually chart? What was the song? <a class="plink" href="cold-cases.html#q-ed00916f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-d0e6b0bf">What is “automaticity” and is it a real word? <a class="plink" href="cold-cases.html#q-d0e6b0bf" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-034608ef">Who got rid of the Black Crowes one? Was it stolen? <a class="plink" href="cold-cases.html#q-034608ef" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-c4b77fd2">Where exactly did the speaker stop on his last drive up north? <a class="plink" href="cold-cases.html#q-c4b77fd2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-ead32042">Why do they call it a brown bag meeting? (Answered in conversation, but debated.) <a class="plink" href="cold-cases.html#q-ead32042" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-c1dfe88e">Where exactly is the brass rabbit hidden? <a class="plink" href="cold-cases.html#q-c1dfe88e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-e6a5f2af">What is the actual connection between Kurt Vile and the War on Drugs? <a class="plink" href="cold-cases.html#q-e6a5f2af" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-feaaecef">Is Kurt Vile from Philly or Detroit? <a class="plink" href="cold-cases.html#q-feaaecef" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-bb8654b5">Which EPL team should they pick? <a class="plink" href="cold-cases.html#q-bb8654b5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-7e0e1cfb">Are the two open seats at the birthday restaurant the counter seats in front of the kitchen? <a class="plink" href="cold-cases.html#q-7e0e1cfb" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-7eea99db">Did anyone actually find the rabbit, or was that a different thing they were looking for? <a class="plink" href="cold-cases.html#q-7eea99db" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-2ba6747a">What is the barber video actually called, and where does it live that isn’t Facebook or Instagram? <a class="plink" href="cold-cases.html#q-2ba6747a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-63022820">Did T.D. stop in Virginia on purpose to see Staunton, or did he just run out of road? <a class="plink" href="cold-cases.html#q-63022820" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-f031913b">What did Nils actually serve? Nobody could remember anything except the bidet bathroom. <a class="plink" href="cold-cases.html#q-f031913b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-91ccba4f">Who was the server at the Greek spot (Nils)? “Fun princess” mentioned but no name confirmed. <a class="plink" href="cold-cases.html#q-91ccba4f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-9ed02a00">Does the cook in the Oliveira hat work there, or did he just leave on good terms? <a class="plink" href="cold-cases.html#q-9ed02a00" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="q-51639293">What is the “glue box” that ties the whole show setup together? <a class="plink" href="cold-cases.html#q-51639293" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+</ul><h2 class="sec">Open loops</h2><p class="sec-note">Still spinning. Possibly forever.</p><hr class="rule"><ul class="evid loop">
+  <li id="l-ab409276">The cymbal swap: B. wants one more but hasn’t pulled the trigger <a class="plink" href="cold-cases.html#l-ab409276" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-37796eba">The watch is in a box. T. is now “a collecting one” apparently <a class="plink" href="cold-cases.html#l-37796eba" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-5b734246">The wheelchair slap: unresolved, cops already gone, no answers expected <a class="plink" href="cold-cases.html#l-5b734246" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-e7873369">Someone nearby had a sailboat they inherited, described as “tortured, right? Tortured, yeah. Suffering artist, John Mayer type. Always looks sad.” Never elaborated on. <a class="plink" href="cold-cases.html#l-e7873369" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-95c2cdf7">The Greco/Roman framework needs a final ruling on who is which. <a class="plink" href="cold-cases.html#l-95c2cdf7" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-021d8f85">The relationship conversation felt unfinished. More dinners probably needed. <a class="plink" href="cold-cases.html#l-021d8f85" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-1d0978d2">The street fight will likely never be reported. B. noted it as “downtown dust up number three.” <a class="plink" href="cold-cases.html#l-1d0978d2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-ee14ad2e">T. has not seen Step Brothers and probably never will unless he gets “a really cool older boyfriend, at least 15 years older, questionably older.” <a class="plink" href="cold-cases.html#l-ee14ad2e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li>
+  <li id="l-f8dc03ee">The S-tier city list was never finalized, especially the international bracket <a class="plink" href="cold-cases.html#l-f8dc03ee" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="l-041754fa">The THC cocktail concept was described as “being developed in real time” with no conclusion <a class="plink" href="cold-cases.html#l-041754fa" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="l-099de36b">Whether to invite the server for a beer was raised and immediately dropped <a class="plink" href="cold-cases.html#l-099de36b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="l-86864143">The Oliveira panna cotta comparison was mentioned but they had been too full to try it at a previous dinner <a class="plink" href="cold-cases.html#l-86864143" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="l-ce0ac57a">Foxes: B. has still never been; Speaker B wants to take him on a jazz Tuesday <a class="plink" href="cold-cases.html#l-ce0ac57a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="l-0a72bf4e">The album release party: Speaker B is considering wearing a vest despite the heat; floated the idea of going viral by collapsing onstage and needing a banana bag <a class="plink" href="cold-cases.html#l-0a72bf4e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="l-9a859ff7">Chiropractic school: B. looked into it once, dropped it at “four years and no nearby schools,” never got to cost <a class="plink" href="cold-cases.html#l-9a859ff7" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="l-2d402ee8">The podcast or livestream they apparently do: discussed whether live format gives cover for rambling; no decision on format <a class="plink" href="cold-cases.html#l-2d402ee8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="l-1be3ff42">Ice cream after dinner: mentioned but not confirmed <a class="plink" href="cold-cases.html#l-1be3ff42" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="l-a642bec5">T.D. is still in transit on I-80. Arrival time unknown. <a class="plink" href="cold-cases.html#l-a642bec5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-f92b1124">L.A.’s travel situation mentioned briefly, unresolved. <a class="plink" href="cold-cases.html#l-f92b1124" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-b6be955a">The gig app idea: “vibe code a gig app right now.” Probably not happening but floated sincerely. <a class="plink" href="cold-cases.html#l-b6be955a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-ec1c3dac">The Excel sheet with files exists somewhere in Discord. G. may be involved. <a class="plink" href="cold-cases.html#l-ec1c3dac" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-89bd3c9b">The set list situation is genuinely unresolved. <a class="plink" href="cold-cases.html#l-89bd3c9b" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-d6c79330">EPL team selection: still undecided, Nottingham Forest and Newcastle both floated seriously <a class="plink" href="cold-cases.html#l-d6c79330" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-0d2ff1fd">The church-bar coup plan: fully abandoned mid-sentence <a class="plink" href="cold-cases.html#l-0d2ff1fd" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-5278054f">The birthday dinner logistics: restaurant confirmed good, date and guest list still being assembled <a class="plink" href="cold-cases.html#l-5278054f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-a53cd9f1">Whether the brass rabbit has ever actually been found by either of them <a class="plink" href="cold-cases.html#l-a53cd9f1" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-9970be4c">The rabbit: one person theoretically wanted to find it, “would have liked for it to happen naturally,” never went looking. No follow-up. <a class="plink" href="cold-cases.html#l-9970be4c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-29f274f6">No Go Topics for the upcoming show: “we didn’t iron these out” <a class="plink" href="cold-cases.html#l-29f274f6" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-daa4ed00">A.’s suggestion to change the Blue Room setlist: shot down, already printed, G. has scissors if needed <a class="plink" href="cold-cases.html#l-daa4ed00" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-98df6d90">D.’s mood at the show: expected to be “wound tight,” someone suggested putting something in his drink <a class="plink" href="cold-cases.html#l-98df6d90" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="l-45e17342">The popcorn ceiling at someone’s dad’s place: dad recently died, ceiling has black mold, the son is a multi-millionaire and should just spend the $14k <a class="plink" href="cold-cases.html#l-45e17342" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+</ul><h2 class="sec">Promised, pending</h2><p class="sec-note">Things people said they would send.</p><hr class="rule"><ul class="evid quest">
+  <li id="p-98844f30">B. said he would find the Italian-American trades term. No timeline given. <a class="plink" href="cold-cases.html#p-98844f30" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li>
+  <li id="p-62a6885f">Look up the Hoggard valedictorian story (it’s on the New York Post and Yahoo) <a class="plink" href="cold-cases.html#p-62a6885f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="p-cf79b8b9">Check social media for the wheelchair slapping incident <a class="plink" href="cold-cases.html#p-cf79b8b9" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li>
+  <li id="p-91014883">Speaker B: will show B. his two silk shirts so B. can feel the difference in thickness <a class="plink" href="cold-cases.html#p-91014883" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li>
+  <li id="p-f55f4b61">The set list needs to go into the Discord. Responsibility unclear but it came up twice. <a class="plink" href="cold-cases.html#p-f55f4b61" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="p-dff51abc">Someone needs to add a thread or channel for the upcoming gig or album. <a class="plink" href="cold-cases.html#p-dff51abc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li>
+  <li id="p-829a67a5">S.N.: already sent a film on Signal to a small group chat, not the IG or group platform <a class="plink" href="cold-cases.html#p-829a67a5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="p-6d420d79">Someone: going to Total Wine tomorrow to grab champagne for G., as a symbolic gesture for the show <a class="plink" href="cold-cases.html#p-6d420d79" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+  <li id="p-c0c6e26d">The barber video: someone was going to find it and play it at the bar. Outcome unknown. <a class="plink" href="cold-cases.html#p-c0c6e26d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li>
+</ul>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/cold-cases.html
+++ b/the_wilmington_papers/cold-cases.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Cold Cases - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/banter.html
+++ b/the_wilmington_papers/dinners/banter.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Banter - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/banter.html
+++ b/the_wilmington_papers/dinners/banter.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Banter - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting VI of 7</div>
+  <h1>Banter</h1>
+  <p class="sub">English-style pub &middot; 13 AUG 2026</p>
+</header>
+<div class="mast-meta">
+  <span><b>8</b> lines</span><span><b>6</b> unanswered</span>
+  <span><b>9</b> claims</span><span><b>4</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">At a bar called Banter, a small neighborhood spot with an English pub feel, no TVs, good music, bar snacks (pretzels, buffalo bits), and cocktails on draft. The vibe was loose, unhurried, and genuinely good. The place had a hidden brass rabbit somewhere on the premises, and finding it gets you a free drink.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-0721288f"><p class="q">&ldquo;You need to stop concerning yourself with my well-being.&rdquo;<a class="plink" href="#x-0721288f" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-b66dd834"><p class="q">&ldquo;I may now violate several laws. See what’s what.&rdquo;<a class="plink" href="#x-b66dd834" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-cd97af75"><p class="q">&ldquo;Chemo banter. That’s not.&rdquo;<a class="plink" href="#x-cd97af75" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-6fb767cc"><p class="q">&ldquo;What kind of concrete box we put this beach in?&rdquo;<a class="plink" href="#x-6fb767cc" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">on funeral banter</div></div><div class="exhibit" id="x-8eef76d8"><p class="q">&ldquo;Some call him the Rizzler.&rdquo;<a class="plink" href="#x-8eef76d8" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-16474d54"><p class="q">&ldquo;I’ve never found it. So therefore it doesn’t exist. And by S.’s logic.&rdquo;<a class="plink" href="#x-16474d54" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-4fe7db61"><p class="q">&ldquo;I hate this place.&rdquo;<a class="plink" href="#x-4fe7db61" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">said warmly, immediately after “I love this place” energy</div></div><div class="exhibit" id="x-5c24229a"><p class="q">&ldquo;Did you have it rolling? I would have given you better content.&rdquo;<a class="plink" href="#x-5c24229a" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">closing line, aware the whole time</div></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>The hidden brass rabbit: rules, size, location hints, whether it even exists, and whether someone stole it</li><li>Picking an English Premier League team to support, with no resolution</li><li>The economics of running a third space, dive bars, and why they’re dying</li><li>The word “banter” itself: what it actually means, whether funeral banter is a thing, whether it requires jokes</li><li>Hotel restaurants and whether they can be good (prompted by a recent meal at Sugo at the Ballast)</li><li>A birthday dinner being planned at a restaurant with reserved seating and rotating salads</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>B. witnessed a bag of quick-crete fall off a truck and explode onto the car in front of him on the bridge road over the 70. The car kept moving. Story reached a full ending.</li><li>Someone’s friend L. works at a restaurant and is very good at turning minor kitchen drama into a 20-minute theatrical story. No specific story was told, just the premise.</li><li>A former league guitarist walked into the restaurant and a party of 15 had so much food they were giving it back. Reached a partial ending.</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>A nonprofit bar structured as a church could avoid taxes, but getting IRS recognition upfront is a lot of work</li><li>Easier to just infiltrate an existing struggling Lutheran church and flip the pews to face each other</li><li>A dive bar making $1 per beer, 2 beers per hour per person, 10 customers: that’s $20/hour, barely minimum wage for one person</li><li>You need at least 4 to 5 staff to run a place like Banter</li><li>Hotel restaurants are either great or “a saltwater Applebee’s”</li><li>The ideal EPL team to support should be northern, rugged, and not one of the big London clubs</li><li>Liverpool is probably the fisherman’s town equivalent, the “New England of England”</li><li>Kurt Vile and the War on Drugs are both from Philly (someone was not sure, Detroit came up as a counter)</li><li>Jack White is from Detroit. Detroit Rock City confirmed.</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>Deep dive into whether “banter” requires playfulness or just means casual back-and-forth, including whether it works as a literary device</li><li>Attempting to locate the hidden brass rabbit by deduction: not in the bathroom, not behind the bar, not under cushions, visible in plain sight, brass/golden/bronzy, about 10 inches, beard on it</li><li>Someone ordered what they thought would be a flowery pink drink called a White Wedding and got something very different. Accepted it without complaint.</li><li>Brief detour into a YouTube ad that asked “would you hire a convicted sex offender?” which played immediately on TV at someone’s house</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>Where exactly is the brass rabbit hidden?</li><li>What is the actual connection between Kurt Vile and the War on Drugs?</li><li>Is Kurt Vile from Philly or Detroit?</li><li>Which EPL team should they pick?</li><li>Are the two open seats at the birthday restaurant the counter seats in front of the kitchen?</li><li>Did anyone actually find the rabbit, or was that a different thing they were looking for?</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><p class="quiet">Nothing explicitly promised, but someone was going to look up EPL standings and team info (never actually did it)</p><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>EPL team selection: still undecided, Nottingham Forest and Newcastle both floated seriously</li><li>The church-bar coup plan: fully abandoned mid-sentence</li><li>The birthday dinner logistics: restaurant confirmed good, date and guest list still being assembled</li><li>Whether the brass rabbit has ever actually been found by either of them</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><p class="quiet">No firm decisions.</p><h2 class="sec">Next dinner</h2><hr class="rule"><ul class="plain"><li>Birthday dinner at the restaurant with the rotating salads and reserved seating (beet salad currently on menu). Guest list includes at least one person named J.O. and someone’s mom. No date locked.</li></ul><p style="margin-top:34px"><a class="mono" style="font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" href="https://notes.granola.ai/t/b015e9a5-cc31-4161-bccd-94bf87eb974b-00demib2">Full transcript &rarr;</a></p><div class="pager"><a href="dram_tree.html">&larr; Dram Tree</a><a href="dram_yard.html">Dram Yard &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/circa_1922.html
+++ b/the_wilmington_papers/dinners/circa_1922.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Circa 1922 - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting III of 7</div>
+  <h1>Circa 1922</h1>
+  <p class="sub">American bistro &middot; 10 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>8</b> lines</span><span><b>7</b> unanswered</span>
+  <span><b>9</b> claims</span><span><b>4</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Circa 1922, Wilmington. Described as “a classic American bistro, if you will.” Two floors, large footprint, bench seating, a piano somewhere in the building. Music playing but barely audible, which bothered B. Food came out as small plates and bites rather than entrees. Dessert arrived as a full mini flight. The server was a recurring source of fascination and mild confusion all night.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-c965b746"><p class="q">&ldquo;Every human being has something of value that they bring to the table. Especially Hitler.&rdquo;<a class="plink" href="#x-c965b746" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-fa6574b0"><p class="q">&ldquo;Do you have more room in your body for liquids?&rdquo;<a class="plink" href="#x-fa6574b0" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-50682668"><p class="q">&ldquo;I think you actually started this, which is why you saw it happen.&rdquo;<a class="plink" href="#x-50682668" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">the server, on the wheelchair slapping, gesturing cosmically</div></div><div class="exhibit" id="x-40033d74"><p class="q">&ldquo;T. admits to thinking about probing all dinner.&rdquo;<a class="plink" href="#x-40033d74" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-ae8e3b97"><p class="q">&ldquo;I’m gonna need the dog to start wearing a condom.&rdquo;<a class="plink" href="#x-ae8e3b97" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-65b0291f"><p class="q">&ldquo;Sparkles&rdquo;<a class="plink" href="#x-65b0291f" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">as the running word for sparkling water</div></div><div class="exhibit" id="x-2fe2c600"><p class="q">&ldquo;the server’s name being guessed as Landon, Land Death, Ter, and S. before being confirmed as the server&rdquo;<a class="plink" href="#x-2fe2c600" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-687d79fe"><p class="q">&ldquo;She’s barking.&rdquo;<a class="plink" href="#x-687d79fe" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">Used first about the other waitress, then repurposed for the blue cheese</div></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>Started as a US-only debate, expanded to global cities</li><li>New York and LA were the only uncontested S-tier US cities</li><li>Chicago debated heavily, T. ultimately voted yes</li><li>Miami, Boston, New Orleans, Philly all floated and mostly rejected</li><li>International tier introduced: Paris, Berlin, London, Rome, Tokyo, Sydney</li><li>Mexico City came up as a legitimate contender</li><li>Washington D.C. landed somewhere between B and B-plus</li><li>No final list was agreed upon</li><li>Three separate stories from around town, told with escalating energy</li><li>The wheelchair slapping incident (witnessed live by both of them downtown)</li><li>The Landfall gated community riot on July 4th</li><li>The Hoggard High School valedictorian Kanye/Hitler quote incident</li><li>Every interaction generated a debrief</li><li>Main question: is the server an alien, a robot, or just extremely literal?</li><li>“Do you have more room in your body for liquids?” became the defining line</li><li>B. considered asking the host for the server’s name under the pretense of leaving a review (“that’s social engineering”)</li><li>S-Tier City Rankings</li><li>Wilmington Local Lore</li><li>The Server the server</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>B. and T. witnessed a man slap a woman in a wheelchair while walking downtown</li><li>They asked the server if they’d heard about it; the server went to find a source</li><li>the server returned with no tea but confirmed the restaurant had a brutal Sunday: 100 covers in 2 hours, usually 90 all day</li><li>The slapping itself was never fully explained or resolved</li><li>Gated community, e-bikes, mob of teenagers crashed through turnstiles</li><li>Locals started fighting a security guard who had worked there 30 years</li><li>Son of a wealthy family punched the guard out; tried to blame the teens</li><li>Kids filmed it on Snapchat/TikTok; story blew up, picked up by the New York Post and Yahoo</li><li>Arrest happened but not for two weeks</li><li>Story reached a conclusion</li><li>Valedictorian (possibly named Kyler or Tyler) quoted Kanye West’s Alex Jones interview in his graduation speech</li><li>The line: “Every human being has something of value that they bring to the table. Especially Hitler.”</li><li>A student objected and grabbed the mic; the school cut her mic</li><li>Speech was suspected to be ChatGPT-written</li><li>Debate about whether he meant to include the Hitler part: consensus was yes, he was “taking the piss”</li><li>He was not in the IB program, which B. held against him</li><li>B. and T. apparently attended an event for a guy named Earl (or Mike?) who broke every bone in his body in a skydiving accident</li><li>They walked in not knowing what it was</li><li>A couple was dancing directly in front of the guy in the wheelchair</li><li>The information placard was an 11x8.5 color printout from the UPS store</li><li>Story reached no formal conclusion, just mutual disbelief</li><li>The Wheelchair Slapping Incident</li><li>The Landfall Riot (July 4th)</li><li>The Hoggard Valedictorian</li><li>The Skydiving Fundraiser That Wasn’t</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>New York and LA are the only true S-tier US cities; everything else is A-tier at best</li><li>Chicago earns S-tier partly because of the Bean, the Bulls 90s lore, two baseball teams, Northwestern, and Lake Michigan</li><li>Lake Michigan is the lake Chicago sits on (stated with some uncertainty)</li><li>Mexico City might be S-tier within its own regional context but unclear on the world scale</li><li>New Zealand is a continent called Oceana, so it has no S-tier cities by default</li><li>The Hoggard valedictorian gamed the system by avoiding the IB program</li><li>Fancy restaurants give small portions so you don’t tire of the flavor before the next course</li><li>THC cocktails are a real and underdeveloped market opportunity, especially while the regulatory window is open</li><li>Chobani makes oat milk, which is why the homemade cocktail got so frothy</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>Long digression on whether the community pool can legally order members out during lightning; the answer at this pool was no, only “advise”</li><li>Debate about whether a 3-second or 10-second lightning rule is correct</li><li>Granola being banned in 30-something states due to age verification requirements</li><li>Dodgeball (the movie) may or may not have been watched once or twice or three times the night before</li><li>The mysterious family group at a nearby table: two girls, two boys, one woman without an apparent partner, formal dresses on a Monday</li><li>Bench seat complaint: B.’s feet don’t touch the floor</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>What exactly is the server’s deal?</li><li>Was the valedictorian actually Jewish, or just quoting Kanye at Jews?</li><li>Did the wheelchair slapping make it onto social media?</li><li>Which lake is Chicago actually on, Michigan or Superior?</li><li>Who were the formally dressed people at the nearby table and what was the occasion?</li><li>Is the dodgeball quote a real callback or did someone just independently say it?</li><li>What was the fourth ingredient in the homemade cocktail before the creamer reveal?</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><ul class="evid quest"><li>Look up the Hoggard valedictorian story (it’s on the New York Post and Yahoo)</li><li>Check social media for the wheelchair slapping incident</li></ul><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>The S-tier city list was never finalized, especially the international bracket</li><li>The THC cocktail concept was described as “being developed in real time” with no conclusion</li><li>Whether to invite the server for a beer was raised and immediately dropped</li><li>The Oliveira panna cotta comparison was mentioned but they had been too full to try it at a previous dinner</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><p class="quiet">No firm decisions.</p><h2 class="sec">Next dinner</h2><hr class="rule"><p class="quiet">Nothing decided. The night ended with the server wishing them “good trouble,” which felt like a benediction.</p><div class="pager"><a href="nils.html">&larr; Nil&#x27;s</a><a href="manna.html">Manna &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/circa_1922.html
+++ b/the_wilmington_papers/dinners/circa_1922.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Circa 1922 - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/dram_tree.html
+++ b/the_wilmington_papers/dinners/dram_tree.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Dram Tree - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/dram_tree.html
+++ b/the_wilmington_papers/dinners/dram_tree.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Dram Tree - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting V of 7</div>
+  <h1>Dram Tree</h1>
+  <p class="sub">Weekday beers &middot; 13 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>11</b> lines</span><span><b>6</b> unanswered</span>
+  <span><b>10</b> claims</span><span><b>5</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Bar or casual venue, weekday afternoon beers</p><p class="setting">Someone mentioned coming from a thrift store earlier in the day</p><p class="setting">Relaxed, rambling, slightly conspiratorial energy</p><p class="setting">Mini corn dogs on the menu. A booth thing was new.</p><p class="setting">Someone stepped outside mid-conversation, possibly to take a call, possibly to escape the communist tangent</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-edec95db"><p class="q">&ldquo;I don’t think I’ve ever met a KISS fan who’s like, oh, I get down.&rdquo;<a class="plink" href="#x-edec95db" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-3d535d2d"><p class="q">&ldquo;That’s a red flag.&rdquo;<a class="plink" href="#x-3d535d2d" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">re: the KISS-loving high school teacher</div></div><div class="exhibit" id="x-adf35ef3"><p class="q">&ldquo;Jungles Run Deep, bro.&rdquo;<a class="plink" href="#x-adf35ef3" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">said about ICP, with full confidence</div></div><div class="exhibit" id="x-b2e123fd"><p class="q">&ldquo;We were the jugglers at Walmart.&rdquo;<a class="plink" href="#x-b2e123fd" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-f7f9855a"><p class="q">&ldquo;The files are in the computer.&rdquo;<a class="plink" href="#x-f7f9855a" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">said while scrolling Discord</div></div><div class="exhibit" id="x-352d985a"><p class="q">&ldquo;I’m starting to sound like Uncle Wade. Oh my God. This is my arc.&rdquo;<a class="plink" href="#x-352d985a" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-f7f9ffd0"><p class="q">&ldquo;Look at us. We’re having beers on a weekday after going to the thrift store.&rdquo;<a class="plink" href="#x-f7f9ffd0" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-629d7222"><p class="q">&ldquo;Who would order eight mini corn dogs?&rdquo;<a class="plink" href="#x-629d7222" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">recurring joke between two people</div></div><div class="exhibit" id="x-9777375f"><p class="q">&ldquo;Are you saying that. Is your phone listening to us right now?&rdquo;<a class="plink" href="#x-9777375f" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">after someone said the word communism</div></div><div class="exhibit" id="x-a09869b8"><p class="q">&ldquo;Chase it, chase it. Skibidi.&rdquo;<a class="plink" href="#x-a09869b8" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-ac0ad93e"><p class="q">&ldquo;Teachers should be allowed to do cocaine.&rdquo;<a class="plink" href="#x-ac0ad93e" aria-label="Link to this line" title="Link to this line">#</a></p></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>Band logistics: Discord channels, set lists, Excel sheets, rehearsal notes, gear announcements. The set list was not in the Discord. It should have been.</li><li>ICP deep dive: Were they southern? West Virginian? Did they chart? B.B. was apparently a big fan. Someone’s team at Walmart was named after ICP.</li><li>KISS discourse: No one present is a KISS fan. A high school teacher who loved KISS was flagged as a red flag. “No good songs. Mostly theatrics.”</li><li>Infrastructure and transit: Started with I-95 being a nightmare, evolved into autonomous vehicles, privatization, eminent domain, Georgetown not having a subway stop, and the World Cup transit situation in New York.</li><li>World Cup NYC: Transit was shut down for blocks around MSG. Trains were 10x normal price. No cars allowed. Someone found this genuinely frustrating, not just inconvenient.</li><li>Teachers and cocaine: Brief but passionate detour into how teachers should be allowed mood-altering substances on the clock, like the military gets certain affordances.</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>Someone worked in a restaurant at 16 with a guy who dressed like Gene Simmons. Story ended there.</li><li>The Walmart ICP team name story: someone’s group chose ICP as their team name at Walmart. No further detail emerged.</li><li>B.B. being a big ICP fan. No resolution, no follow-up.</li><li>T.D. driving down from PA: currently on I-80 in transit. Someone speculated he stopped somewhere overnight, like the speaker did on a previous drive.</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>ICP is from the Midwest but gives off West Virginia vibes. Someone insisted this tracks culturally even though it makes no geographic sense.</li><li>Georgetown, D.C. has no subway stop because wealthy residents did not want it. Classist, not racist, per the speaker.</li><li>Cambridge probably has a parallel situation to Georgetown.</li><li>Autonomous vehicles will eventually turn roads into de facto train systems, making rail infrastructure redundant.</li><li>I-95 through the Baltimore corridor is always a disaster unless you roll through at 3am.</li><li>The World Cup “made a market from nothing” by banning cars and forcing everyone onto 10x-priced trains.</li><li>The government has been inept at infrastructure for 100 years and cannot catch up now.</li><li>If Tesla goes under and “Enrons us,” there is nothing to show for the investment.</li><li>Eminent domain is now commonly used to favor affluent private developers over communities, not for schools or fire stations.</li><li>The conversation ended with someone suggesting their shared politics amounted to advocating for a “classless, stateless experiment,” i.e., communism.</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>“Automaticity” or “automatissim”: one person kept trying to use this word, the other refused to accept it as real. Eventually resolved as “autonomy.”</li><li>Brown bag meeting explainer: someone had to leave for a work “brown bag.” The other person did not know what that meant. Full etymology provided. Concluded: it means bring your lunch, it signals informality.</li><li>The severance analogy for the teaching workday: eat lunch fast, take a piss, dissociate for four more hours, go home.</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>Is ICP from the Midwest, West Virginia, or LA? Someone refused to look it up.</li><li>Did ICP actually chart? What was the song?</li><li>What is “automaticity” and is it a real word?</li><li>Who got rid of the Black Crowes one? Was it stolen?</li><li>Where exactly did the speaker stop on his last drive up north?</li><li>Why do they call it a brown bag meeting? (Answered in conversation, but debated.)</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><ul class="evid quest"><li>The set list needs to go into the Discord. Responsibility unclear but it came up twice.</li><li>Someone needs to add a thread or channel for the upcoming gig or album.</li></ul><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>T.D. is still in transit on I-80. Arrival time unknown.</li><li>L.A.’s travel situation mentioned briefly, unresolved.</li><li>The gig app idea: “vibe code a gig app right now.” Probably not happening but floated sincerely.</li><li>The Excel sheet with files exists somewhere in Discord. G. may be involved.</li><li>The set list situation is genuinely unresolved.</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><ul class="plain"><li>The set list should go in the Discord. No one confirmed they would actually do it.</li><li>A thread for the gig or album was suggested. Not confirmed.</li></ul><h2 class="sec">Next dinner</h2><hr class="rule"><p class="quiet">No next dinner discussed. T.D. arriving soon may constitute the next gathering.</p><div class="pager"><a href="manna.html">&larr; Manna</a><a href="banter.html">Banter &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/dram_yard.html
+++ b/the_wilmington_papers/dinners/dram_yard.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Dram Yard - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/dram_yard.html
+++ b/the_wilmington_papers/dinners/dram_yard.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Dram Yard - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting VII of 7</div>
+  <h1>Dram Yard</h1>
+  <p class="sub">Late dinner, Market St &middot; 13 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>10</b> lines</span><span><b>6</b> unanswered</span>
+  <span><b>7</b> claims</span><span><b>5</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Late dinner at a restaurant in Wilmington, NC, likely called Dram Yard or nearby on Market Street. Corner bar seating. Sparkling water from Mamaroneck, NY opened the night. The mood was loose, well-fed, and philosophically wandering. This was the last or second-to-last dinner of what appears to have been a multi-day trip. Everyone was full, slightly buzzed, and in no hurry.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-bb069542"><p class="q">&ldquo;All input is welcome, just not correct.&rdquo;<a class="plink" href="#x-bb069542" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">A., via text, about the setlist</div></div><div class="exhibit" id="x-19ee7cc7"><p class="q">&ldquo;My pronouns are cake talk.&rdquo;<a class="plink" href="#x-19ee7cc7" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-049375a8"><p class="q">&ldquo;Lobster. Too flavorful.&rdquo;<a class="plink" href="#x-049375a8" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">recurring complaint about abundance of good things</div></div><div class="exhibit" id="x-1b4bfe22"><p class="q">&ldquo;Rent free going away.&rdquo;<a class="plink" href="#x-1b4bfe22" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">about someone still living in someone’s head</div></div><div class="exhibit" id="x-911f3cea"><p class="q">&ldquo;We shan’t.&rdquo;<a class="plink" href="#x-911f3cea" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">escalating through “we shouldn’t, we could, we may, we shan’t”</div></div><div class="exhibit" id="x-907d7ba5"><p class="q">&ldquo;I’m edging myself as we speak.&rdquo;<a class="plink" href="#x-907d7ba5" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">re: anticipation for the upcoming show</div></div><div class="exhibit" id="x-31dc9b4a"><p class="q">&ldquo;Splendid ordering. We’re just living our truths.&rdquo;<a class="plink" href="#x-31dc9b4a" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-f251e9e4"><p class="q">&ldquo;She boofed us in the back corner and then she rattled my brain.&rdquo;<a class="plink" href="#x-f251e9e4" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-6bca8b27"><p class="q">&ldquo;Cool them jets. I’m at a five. You’re not.&rdquo;<a class="plink" href="#x-6bca8b27" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-17e57143"><p class="q">&ldquo;It’s like making a playlist. That’s the only thing I can liken it to.&rdquo;<a class="plink" href="#x-17e57143" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">on ordering adventurously</div></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>Tasting menu vs. ordering off menu: debated briefly, landed on ordering what they actually wanted</li><li>Reconstructing the full trip itinerary night by night: Oliveira (Saturday), grocery store and cocktails (Saturday night), Saores brunch (Sunday), Nils (Sunday night), fast food at the apartment (Monday/Tuesday, disputed), Circa (Tuesday), Mano (Wednesday), Dram Yard (Thursday)</li><li>Whether to get dessert here or walk to Hillwinds ice cream after</li><li>Tattoos: who has them, where to get one, what to get, placement philosophy</li><li>Women ordering at restaurants and the impossible position it puts servers in</li><li>T.D. driving from Pennsylvania and stopping in Virginia, possibly to check out Staunton</li><li>A friend named S.N. sending a film on Signal, dropping it in the wrong chat, “going back to his old ways”</li><li>Stock talk: W. sold too early, TSLL down 36%, S.’s picks under scrutiny</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>The barber video: someone remembered a line from a video involving a barber and a customer rant, tried to find it on Instagram, played it at low volume like a boomer, never fully landed the clip. Story unresolved.</li><li>C. the Greek barber: had a baby, lived in Riva, referenced as an example of people who actually want to be kids. Story trailed off.</li><li>The Nils bathroom: went down half a flight of stairs, had bidets, that’s basically all anyone remembered. The food itself was a blank.</li><li>Wheelchair pizza night: involved two beers, cocktails, gummies, and “all the excitement of the fight.” Details murky by design.</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>Non-point source pollution theory applied to bad people: small bad actors outnumber big bad ones, so on aggregate there are more baddies</li><li>“On aggregate” debated at length; concluded it means “in total, all things considered,” not averaging</li><li>Popcorn ceilings with black mold cannot be rectified, must come out entirely</li><li>Truly old people have more tattoos because they were young when tattoos were a thing</li><li>Military labs working on artificial viruses, possibly to get ahead of immunology threats, “but it’s gonna get out and we’re all gonna die from a super virus”</li><li>The pizza delivery metric in D.C. as a predictor of imminent military action: “we’re about to bomb someone, there’s a lot of pizza”</li><li>Certified forklift operators (CFOs) are a distinct and elite class</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>Calculating max occupancy of the restaurant: 12 at tables, 12 at bar, 20 standing behind bar, arrived at roughly 44 to 80 depending on methodology. Became its own math exercise.</li><li>The sparkling water bottle origin: debated between Long Island, Hudson Valley, Catskills, and Mamaroneck. “Those are microscopic bubbles that almost hurt.”</li><li>The gun safe: attempted to crack it by feel, got to the third click, explained the full mechanism in detail. No success confirmed.</li><li>The camera moment: a nearby couple stared at the camera, one person thought they were being engaged, the other realized they were just looking past them at water bottles. Resolved awkwardly.</li><li>Forklift operator competitions on German television: witnessed in person, involved filling a glass with microscopic precision. Certified.</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>What is the barber video actually called, and where does it live that isn’t Facebook or Instagram?</li><li>Did T.D. stop in Virginia on purpose to see Staunton, or did he just run out of road?</li><li>What did Nils actually serve? Nobody could remember anything except the bidet bathroom.</li><li>Who was the server at the Greek spot (Nils)? “Fun princess” mentioned but no name confirmed.</li><li>Does the cook in the Oliveira hat work there, or did he just leave on good terms?</li><li>What is the “glue box” that ties the whole show setup together?</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><ul class="evid quest"><li>S.N.: already sent a film on Signal to a small group chat, not the IG or group platform</li><li>Someone: going to Total Wine tomorrow to grab champagne for G., as a symbolic gesture for the show</li><li>The barber video: someone was going to find it and play it at the bar. Outcome unknown.</li></ul><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>The rabbit: one person theoretically wanted to find it, “would have liked for it to happen naturally,” never went looking. No follow-up.</li><li>No Go Topics for the upcoming show: “we didn’t iron these out”</li><li>A.’s suggestion to change the Blue Room setlist: shot down, already printed, G. has scissors if needed</li><li>D.’s mood at the show: expected to be “wound tight,” someone suggested putting something in his drink</li><li>The popcorn ceiling at someone’s dad’s place: dad recently died, ceiling has black mold, the son is a multi-millionaire and should just spend the $14k</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><ul class="plain"><li>Ordered: oysters (half dozen), tuna tostada, duck lumpia, both salads, market fish (tilefish), roast duck breast</li><li>Skipped wine pairing: “definitely be drunk, shouldn’t try drunk”</li><li>Dessert: splitting the popcorn creme brulee, then walking to Hillwinds for ice cream</li><li>Tomorrow: leave around noon, drop dogs off, check into hotel (after 3pm), grab a drink, get to the venue for sound check</li><li>Champagne from Total Wine for G.</li></ul><h2 class="sec">Next dinner</h2><hr class="rule"><ul class="plain"><li>Saturday night still technically available in Wilmington</li><li>One suggestion: a Greek spot toward Wrightsville Beach, described as having “really nice items” but a 25-minute drive</li><li>General consensus: they hit the good spots, no strong push for a specific new place</li></ul><p style="margin-top:34px"><a class="mono" style="font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" href="https://notes.granola.ai/t/b162fb15-6ed6-462b-a894-a9657ab2902d-00demib2">Full transcript &rarr;</a></p><div class="pager"><a href="banter.html">&larr; Banter</a><a href="../cold-cases.html">Cold Cases &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/manna.html
+++ b/the_wilmington_papers/dinners/manna.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Manna - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting IV of 7</div>
+  <h1>Manna</h1>
+  <p class="sub">Farm-to-table, Princess St &middot; 12 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>11</b> lines</span><span><b>8</b> unanswered</span>
+  <span><b>9</b> claims</span><span><b>5</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Manna, a farm-to-table restaurant on Princess Street in Wilmington, NC. Wednesday night, around 7:30pm. Menu changes daily, extremely seasonal. The place was busier than expected for a Wednesday, with a lot of overdressed people walking by outside. The decor was described as disjointed and vaguely unsettling. The music was a Spotify playlist called “70s Soft Rock Bottoms,” which switched over at 8pm. The vibe was loose, full, and wandering.</p><p class="setting">They ordered oysters (six, local), smoked fish, crab cakes, melon, grouper (which had bones), and a pork chop that took 30 minutes to rest. Drinks included a Cooler Spritz and a Stiegl grapefruit radler. Passed on dessert. Possibly heading to get ice cream after.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-d4072ea3"><p class="q">&ldquo;Risk it for the biscuit, brother&rdquo;<a class="plink" href="#x-d4072ea3" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">B., after Speaker B worried about grapefruit and his meds</div></div><div class="exhibit" id="x-6474e5df"><p class="q">&ldquo;Let’s not get too crazy&rdquo;<a class="plink" href="#x-6474e5df" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">the server, unprompted</div></div><div class="exhibit" id="x-a5b6cab2"><p class="q">&ldquo;Duck confit sounds fucking fire&rdquo;<a class="plink" href="#x-a5b6cab2" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-c19312d0"><p class="q">&ldquo;I’m a sucker for a pork chop&rdquo;<a class="plink" href="#x-c19312d0" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">said twice, on different nights</div></div><div class="exhibit" id="x-c3c5c480"><p class="q">&ldquo;Parsley is the collapse of what a good time&rdquo;<a class="plink" href="#x-c3c5c480" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-5983a6e4"><p class="q">&ldquo;I’m gonna ride with that. Pre-felony.&rdquo;<a class="plink" href="#x-5983a6e4" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-8043ff8d"><p class="q">&ldquo;I don’t even want to know your name. I’m only going to call you your roster number.&rdquo;<a class="plink" href="#x-8043ff8d" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-2aa01771"><p class="q">&ldquo;Stays cracking fools 9 to 5&rdquo;<a class="plink" href="#x-2aa01771" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">on the chiropractor’s schedule</div></div><div class="exhibit" id="x-5e7ea7c2"><p class="q">&ldquo;What a great job.&rdquo;<a class="plink" href="#x-5e7ea7c2" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">on the chiropractor working noon to 5, four days a week</div></div><div class="exhibit" id="x-c72cadcb"><p class="q">&ldquo;We can’t reject the null.&rdquo;<a class="plink" href="#x-c72cadcb" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">on whether Wilmington is actually fancy</div></div><div class="exhibit" id="x-60a1d8e2"><p class="q">&ldquo;I think the sound man is playing his own playlist to get people to leave.&rdquo;<a class="plink" href="#x-60a1d8e2" aria-label="Link to this line" title="Link to this line">#</a></p></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>Foxes bar: a late-night sandwich spot Speaker B discovered after jazz nights on Tuesdays, never properly relayed to B.</li><li>Chiropractors: B. goes every week or so for maintenance after BJ’s class cranks his neck; includes stretching, STEM machine, and traction</li><li>Chiropractic school: B. actually looked into it; four years, no nearby schools, dropped the idea fast</li><li>Escape rooms: too many in downtown Wilmington, at least three, possibly more</li><li>Steely Dan lore: they barely toured, their name is a nickname for a dildo, and the restaurant played three of their songs back to back</li><li>Paranoia and perception of reality: started as a Truman Show joke, went somewhere more interesting</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>Speaker B at the pool: a mom (K.) and her daughter (K.L., maybe) swam over to him while he was checking chemicals, introduced themselves, mom was attractive; story ended there, no resolution</li><li>M. at the pool: a different woman approached Speaker B at 6:30pm while he was closing out and complimented his appearance; he was into it</li><li>Speaker B going to Foxes after jazz: decompressed, showered, went out hungry, got a sandwich on Texas toast with fries instead of fast food; presented as a personal win</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>Grapefruit interacts badly with certain medications by affecting a “very specific mechanism”; Speaker B risked it anyway</li><li>The well-dressed people walking by were probably going to a show at the Thalian Theater; confirmed nothing was actually playing that night</li><li>Silk does not breathe, which makes the scarf the woman outside was wearing inexplicable</li><li>Chiropractors make great money: cash pay, no co-pays, multiple concurrent patients, plus an acupuncturist on staff</li><li>The Steely Dan name comes from a dildo reference; Speaker B claims he told B. this earlier that same day</li><li>Steely Dan only really toured on their first album</li><li>The “70s Soft Rock Bottoms” Spotify playlist is responsible for three Steely Dan songs and an Atlanta Rhythm Section track in one sitting</li><li>Parsley either cleanses the palate before eating or freshens breath after; nobody knew which, and it fades fast anyway</li><li>What they thought was parsley on the pork chop was actually cilantro</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>Arrow symbols on the menu: turned out to indicate wine pairing options, not sourcing info</li><li>The bell pepper in a dish: debated whether it was a shishito; Speaker B realized mid-conversation he was reading last night’s menu</li><li>Numbering students instead of learning their names: Speaker B considered piloting it in one class, then talked himself out of it</li><li>The man in the all-white suit crossing the street: briefly became a Truman Show conspiracy, then a paranoia tangent</li><li>Whether the woman outside was upset or just wearing a dress with a tie: unresolved</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>What does the arrow symbol on the menu actually indicate for the oysters specifically?</li><li>What was the bell pepper in the dish, really? Shishito? Stuffed pepper? Something else?</li><li>Is the woman outside upset or just wearing a wrap dress?</li><li>What is the actual success rate of the escape rooms downtown?</li><li>Which Steely Dan song came before “Reeling in the Years”?</li><li>Does silk actually breathe or not?</li><li>Who is the man in the all-white suit and where was he going?</li><li>What was playing at the Thalian Theater, if anything?</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><ul class="evid quest"><li>Speaker B: will show B. his two silk shirts so B. can feel the difference in thickness</li></ul><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>Foxes: B. has still never been; Speaker B wants to take him on a jazz Tuesday</li><li>The album release party: Speaker B is considering wearing a vest despite the heat; floated the idea of going viral by collapsing onstage and needing a banana bag</li><li>Chiropractic school: B. looked into it once, dropped it at “four years and no nearby schools,” never got to cost</li><li>The podcast or livestream they apparently do: discussed whether live format gives cover for rambling; no decision on format</li><li>Ice cream after dinner: mentioned but not confirmed</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><p class="quiet">No firm decisions.</p><h2 class="sec">Next dinner</h2><hr class="rule"><p class="quiet">No next dinner discussed. Foxes on a jazz Tuesday was loosely floated as a future outing.</p><p style="margin-top:34px"><a class="mono" style="font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" href="https://notes.granola.ai/t/a3d68547-cadf-4294-9d5e-4784564f1cd1-00demib2">Full transcript &rarr;</a></p><div class="pager"><a href="circa_1922.html">&larr; Circa 1922</a><a href="dram_tree.html">Dram Tree &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/manna.html
+++ b/the_wilmington_papers/dinners/manna.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Manna - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/nils.html
+++ b/the_wilmington_papers/dinners/nils.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Nil&#x27;s - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting II of 7</div>
+  <h1>Nil&#x27;s</h1>
+  <p class="sub">Greek, downtown &middot; 9 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>10</b> lines</span><span><b>7</b> unanswered</span>
+  <span><b>6</b> claims</span><span><b>4</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Greek restaurant in downtown Wilmington, Sunday evening. They arrived after witnessing a street altercation outside. The kitchen closed early, which added mild pressure to the back half of the meal. The mood was loose, funny, and occasionally sincere. A bidet in the public restroom became a recurring point of civic pride and confusion.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-395dd2fd"><p class="q">&ldquo;I am Greek for Greek.&rdquo;<a class="plink" href="#x-395dd2fd" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-2fc384ad"><p class="q">&ldquo;Are you Greco or Roman?&rdquo;<a class="plink" href="#x-2fc384ad" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">proposed as the definitive differentiator</div></div><div class="exhibit" id="x-a4714925"><p class="q">&ldquo;I’m getting Roman hard.&rdquo;<a class="plink" href="#x-a4714925" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-59705ff3"><p class="q">&ldquo;I’m ripped torn because I am ripped torn over that pino.&rdquo;<a class="plink" href="#x-59705ff3" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-4d60c78c"><p class="q">&ldquo;I destroyed the evidence. The evidence still exists.&rdquo;<a class="plink" href="#x-4d60c78c" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-950098e2"><p class="q">&ldquo;You Bogarten your own bread? That’s so uncool.&rdquo;<a class="plink" href="#x-950098e2" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-9f58dcbc"><p class="q">&ldquo;Unless your name is A.S., it’s not happening.&rdquo;<a class="plink" href="#x-9f58dcbc" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-9962a021"><p class="q">&ldquo;They provocated. They were the provocateurs.&rdquo;<a class="plink" href="#x-9962a021" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-55cc719c"><p class="q">&ldquo;Kill this recording quick.&rdquo;<a class="plink" href="#x-55cc719c" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-f344273a"><p class="q">&ldquo;I had to close all the windows so nobody could see me. I got in there with my hands.&rdquo;<a class="plink" href="#x-f344273a" aria-label="Link to this line" title="Link to this line">#</a></p><div class="gloss">The server, on the mushroom burrata</div></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>The Greco/Roman taxonomy: an extended attempt to invent terminology for sexual preferences using Greek and Roman history as a framework. Never fully resolved but generated significant vocabulary.</li><li>Relationship dynamics: B. talked at length about feeling unable to have friends over, the implicit communication of discomfort, and what that signals about a relationship. Honest and unforced.</li><li>The street fight: a man allegedly slapped a woman in a wheelchair outside a nearby storefront. Both tried to reconstruct the timeline and motive. No conclusions reached.</li><li>OnlyFans as a career path and cultural artifact: started as a joke, went deep, ended with B. realizing he was being recorded.</li><li>City tier rankings: San Diego as A-tier, Boston as S-tier, Austin as A-tier, Dallas as B-tier. Loose and undefended.</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>The street fight: B. witnessed it, T. partially witnessed it. The wheelchair detail was disputed. The alleged slapper may have been provoked. Story ended without resolution.</li><li>The girl who dropped her OnlyFans the minute she turned 18 after hyping it for months and made millions. Neither could remember her name. Story confirmed as real, details unverified.</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>The reservation-only policy is a gatekeeper move, not a capacity issue. The restaurant had many empty tables.</li><li>The wheelchair woman may have provoked the slapper. “They should have known the hit rate on a wheelchair person.”</li><li>The bidet in a public Wilmington restaurant represents a genuine cultural leap. B. has been in public restrooms on multiple continents and has never seen one offered.</li><li>Greek music is more Eastern and Byzantine than Italian. “A little more poly.” Confident but unverified.</li><li>The OnlyFans birthday drop strategy is marketing genius. The legal technicality around photo timing was raised and then abandoned.</li><li>“Nona” might be Polish, not Italian. Disputed. Unresolved.</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>The bidet: discovered in the bathroom mid-meal, became a recurring symbol of Wilmington’s unexpected cultural ambition.</li><li>The retired cop at 4 o’clock: a man at a nearby table had been watching the whole time. Identified as probably Irish, probably a retired cop, definitely noticing things.</li><li>The olive incident: B. launched an olive across the floor. A nearby diner witnessed the entire arc. Evidence was destroyed but the witness remained.</li><li>The music: went from electronic to Latin to what sounded like an 80s brass section. Neither could identify it as definitively Greek.</li><li>Binder clips: B. has been into binder clips lately. T. noticed. Neither wanted to make it a thing. It became a thing briefly anyway.</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>Can you be Greek for Greek? (Resolved: yes, in all permutations.)</li><li>Is “Greco” the giver or the receiver? (Unresolved. The Greeks preceded the Romans chronologically, which was considered relevant but not decisive.)</li><li>Who was the OnlyFans birthday girl?</li><li>Was there actually a wheelchair? B. second-guessed his own memory.</li><li>Is “Nona” Polish or Italian?</li><li>What actually started the fight outside?</li><li>What year did Step Brothers come out? (Someone said 2006. Unverified.)</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><p class="quiet">Nothing formally promised. The server said she would bring the check when ready. She did.</p><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>The Greco/Roman framework needs a final ruling on who is which.</li><li>The relationship conversation felt unfinished. More dinners probably needed.</li><li>The street fight will likely never be reported. B. noted it as “downtown dust up number three.”</li><li>T. has not seen Step Brothers and probably never will unless he gets “a really cool older boyfriend, at least 15 years older, questionably older.”</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><p class="quiet">No firm decisions.</p><h2 class="sec">Next dinner</h2><hr class="rule"><ul class="plain"><li>T. lives in the northeast. B. said “I can’t speak for me” when the server asked if she’d see them again. No date or location proposed. The Italian dinner was mentioned as a future plan, loosely.</li></ul><p style="margin-top:34px"><a class="mono" style="font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" href="https://notes.granola.ai/t/ee555d18-a15a-42fa-8d73-dd58ce2629f7-00demib2">Full transcript &rarr;</a></p><div class="pager"><a href="sea_bird.html">&larr; Sea Bird</a><a href="circa_1922.html">Circa 1922 &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/dinners/nils.html
+++ b/the_wilmington_papers/dinners/nils.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Nil&#x27;s - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/sea_bird.html
+++ b/the_wilmington_papers/dinners/sea_bird.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Sea Bird - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/dinners/sea_bird.html
+++ b/the_wilmington_papers/dinners/sea_bird.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sea Bird - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="dinner-head">
+  <div class="num">Sitting I of 7</div>
+  <h1>Sea Bird</h1>
+  <p class="sub">Outdoor bar &middot; 9 AUG 2026 &middot; with T.</p>
+</header>
+<div class="mast-meta">
+  <span><b>8</b> lines</span><span><b>4</b> unanswered</span>
+  <span><b>6</b> claims</span><span><b>4</b> open loops</span>
+</div>
+<h2 class="sec">Setting and vibe</h2><hr class="rule"><p class="setting">Outdoor or semi-outdoor bar/restaurant setting, hot night (100 degrees), drinks flowing, edibles in effect. Closing time was looming. A dancer was twirling nearby with a plastic cup of tequila. Something happened involving a woman in a wheelchair getting slapped, and the whole block was buzzing about it.</p><h2 class="sec">Exhibits</h2><p class="sec-note">Lines entered into the record.</p><hr class="rule"><div class="exhibit" id="x-dbdd7262"><p class="q">&ldquo;You got away with it. You got away with it.&rdquo;<a class="plink" href="#x-dbdd7262" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-3f7a1a94"><p class="q">&ldquo;I wore it this day. And they’d be like. And I’m not lying. I am not lying.&rdquo;<a class="plink" href="#x-3f7a1a94" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-235f9339"><p class="q">&ldquo;The cops are already gone. They clock off at 7 here. It’s the wild, wild west until 6am. Budget cuts. The streets, you understand?&rdquo;<a class="plink" href="#x-235f9339" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-fdc3c66e"><p class="q">&ldquo;The streets will protect them.&rdquo;<a class="plink" href="#x-fdc3c66e" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-8713e36c"><p class="q">&ldquo;He kind of looked like a pedo, but I don’t think that’s enough for a slap.&rdquo;<a class="plink" href="#x-8713e36c" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-8184fb87"><p class="q">&ldquo;Grail symbols.&rdquo;<a class="plink" href="#x-8184fb87" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-c8203d99"><p class="q">&ldquo;Fluey and juicy.&rdquo;<a class="plink" href="#x-c8203d99" aria-label="Link to this line" title="Link to this line">#</a></p></div><div class="exhibit" id="x-e120cef6"><p class="q">&ldquo;Go ahead and get that TPS report.&rdquo;<a class="plink" href="#x-e120cef6" aria-label="Link to this line" title="Link to this line">#</a></p></div><h2 class="sec">Main conversation threads</h2><hr class="rule"><ul class="plain"><li>The origin of terrazzo flooring and whether there’s a specific trade word for scrap/leftover building materials</li><li>A watch T. bought, wore once in public, and got away with completely unnoticed</li><li>Cymbals: what makes them good, Turkish vs. other brands, hand hammering, and whether B. should swap in one more</li><li>The wheelchair slap incident happening nearby and what could possibly justify it</li><li>A Law and Order episode about a forced confession at gunpoint</li></ul><h2 class="sec">Stories started</h2><hr class="rule"><ul class="plain"><li>T. bought a limited-edition yacht race watch, wore it to a fancy dinner in Cape May with A.S., Se, and C.H., and not one of them noticed. Watch is now in a box. Story reached a satisfying conclusion: “You got away with it.”</li><li>B. has been quietly upgrading his cymbal collection: $800 high hats, two ride cymbals around $600 each, and eyeing one more. Story trailed off into cymbal theory.</li><li>A Law and Order episode called “Confession” where a grieving detective forces a confession at gunpoint from a suspect. B. remembered it vividly but the thread dissolved before any real point landed.</li></ul><h2 class="sec">Theories and claims</h2><hr class="rule"><ul class="evid claim"><li>Terrazzo originated in 15th century Venice, workers pressed marble scraps into clay and sealed the surface with goat’s milk</li><li>There is a specific Italian-American trades term for leftover building materials, possibly with mob connections, that B. could not retrieve</li><li>The wheelchair slap would only be justifiable if someone made a cruel joke about a very recently deceased person close to the slapper</li><li>Istanbul cymbals are currently more coveted than Zildjian, Paiste, and Sabian</li><li>Hand hammering gives each cymbal a unique character and is part of what makes them worth buying</li><li>Turkey is still the gold standard for cymbal manufacturing</li></ul><h2 class="sec">Side quests</h2><hr class="rule"><ul class="evid quest"><li>CW&amp;T, a Brooklyn design house: came up because T.’s folding scissors are from there, and apparently so is B.’s brass pen that S. gave him</li><li>The nearby dancer with the tequila in a plastic cup who was “twirling” and described as chiseled but slim: “We were observed. He had questions.”</li><li>T. almost brought folding scissors through TSA and was prepared to be very frustrated if they got confiscated</li></ul><h2 class="sec">Unanswered questions</h2><hr class="rule"><ul class="evid "><li>What is the specific Italian-American trades term for scrap building materials? B. said “that’s gonna haunt me now.”</li><li>What actually preceded the wheelchair slap? “That’s what we all want to know.”</li><li>Which Law and Order episode is “Confession” exactly, and was the cop dirty or just grieving?</li><li>What was the name of the bartender or attendee someone was trying to remember? Landed on “A.M.” but with low confidence.</li></ul><h2 class="sec">Promised to send</h2><hr class="rule"><ul class="evid quest"><li>B. said he would find the Italian-American trades term. No timeline given.</li></ul><h2 class="sec">Open loops</h2><hr class="rule"><ul class="evid loop"><li>The cymbal swap: B. wants one more but hasn’t pulled the trigger</li><li>The watch is in a box. T. is now “a collecting one” apparently</li><li>The wheelchair slap: unresolved, cops already gone, no answers expected</li><li>Someone nearby had a sailboat they inherited, described as “tortured, right? Tortured, yeah. Suffering artist, John Mayer type. Always looks sad.” Never elaborated on.</li></ul><h2 class="sec">Decisions or plans</h2><hr class="rule"><p class="quiet">No firm decisions.</p><h2 class="sec">Next dinner</h2><hr class="rule"><p class="quiet">Nothing decided. Drinks were still being ordered as the notes end: “I will do the Paloma.”</p><p style="margin-top:34px"><a class="mono" style="font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded)" href="https://notes.granola.ai/t/650ff1e6-9995-40d9-b899-60d461e759c1-00demib2">Full transcript &rarr;</a></p><div class="pager"><a href="../record.html">&larr; The Record</a><a href="nils.html">Nil&#x27;s &rarr;</a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="../index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/index.html
+++ b/the_wilmington_papers/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/index.html
+++ b/the_wilmington_papers/index.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="index.html" aria-current="page">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="mast">
+  <div class="kicker">Exhibits 1&ndash;66 &middot; entered into evidence</div>
+  <h1 class="title">The Wilmington Papers</h1>
+  <p class="dek">Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.</p>
+  <div class="mast-meta"><span><b>7</b> dinners</span><span><b>7</b> venues</span><span><b>4</b> days</span><span><b>1</b> unresolved slap</span></div>
+</header>
+
+<div class="exhibit">
+  <p class="q">&ldquo;You got away with it. You got away with it.&rdquo;</p>
+  <div class="src">Exhibit A &middot; Sea Bird &middot; 9 AUG 2026</div>
+</div>
+<div class="stat-row"><div class="stat"><b>44</b><span>questions unanswered</span></div><div class="stat"><b>31</b><span>loops left open</span></div><div class="stat"><b>56</b><span>claims on record</span></div><div class="stat"><b>0</b><span>firm decisions</span></div></div><h2 class="sec">Recurring threads</h2><p class="sec-note">Subjects that refused to die across multiple sittings.</p><hr class="rule"><div class="thread"><h3>the slap <span class="count">4 sittings</span></h3><div class="where"><a href="dinners/sea_bird.html">Sea Bird</a>, <a href="dinners/nils.html">Nil&#x27;s</a>, <a href="dinners/circa_1922.html">Circa 1922</a>, <a href="dinners/dram_yard.html">Dram Yard</a></div></div><div class="thread"><h3>the brass rabbit <span class="count">2 sittings</span></h3><div class="where"><a href="dinners/banter.html">Banter</a>, <a href="dinners/dram_yard.html">Dram Yard</a></div></div><div class="thread"><h3>city tiers <span class="count">2 sittings</span></h3><div class="where"><a href="dinners/nils.html">Nil&#x27;s</a>, <a href="dinners/circa_1922.html">Circa 1922</a></div></div><div class="thread"><h3>the set list <span class="count">2 sittings</span></h3><div class="where"><a href="dinners/dram_tree.html">Dram Tree</a>, <a href="dinners/dram_yard.html">Dram Yard</a></div></div><div class="thread"><h3>bidets <span class="count">2 sittings</span></h3><div class="where"><a href="dinners/nils.html">Nil&#x27;s</a>, <a href="dinners/dram_yard.html">Dram Yard</a></div></div><h2 class="sec">Where to start</h2><hr class="rule"><div class="docket"><a class="doc" href="cold-cases.html"><span class="num">01</span><span><span class="v">Cold Cases</span><br><span class="k">Every question nobody answered, and every loop still spinning.</span></span><span class="d">75 items</span></a><a class="doc" href="record.html"><span class="num">02</span><span><span class="v">The Record</span><br><span class="k">All the dinners, in the order they happened.</span></span><span class="d">7 nights</span></a><a class="doc" href="canon.html"><span class="num">03</span><span><span class="v">Canon</span><br><span class="k">Claims asserted confidently, verified never.</span></span><span class="d">56 claims</span></a><a class="doc" href="quotable.html"><span class="num">04</span><span><span class="v">Quotable</span><br><span class="k">Pull a line at random from the transcript.</span></span><span class="d">66 lines</span></a></div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/quotable.html
+++ b/the_wilmington_papers/quotable.html
@@ -1,0 +1,312 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Quotable - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html" aria-current="page">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="mast">
+  <div class="kicker">Section IV</div>
+  <h1 class="title">Quotable</h1>
+  <p class="dek">Every line worth preserving, served one at a time.</p>
+</header>
+<div id="slot"></div><button class="btn" id="again">Pull another line</button><h2 class="sec">The complete set</h2><hr class="rule"><ul class="evid quest"><li id="x-dbdd7262">&ldquo;You got away with it. You got away with it.&rdquo; <a class="plink" href="quotable.html#x-dbdd7262" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-3f7a1a94">&ldquo;I wore it this day. And they’d be like. And I’m not lying. I am not lying.&rdquo; <a class="plink" href="quotable.html#x-3f7a1a94" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-235f9339">&ldquo;The cops are already gone. They clock off at 7 here. It’s the wild, wild west until 6am. Budget cuts. The streets, you understand?&rdquo; <a class="plink" href="quotable.html#x-235f9339" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-fdc3c66e">&ldquo;The streets will protect them.&rdquo; <a class="plink" href="quotable.html#x-fdc3c66e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-8713e36c">&ldquo;He kind of looked like a pedo, but I don’t think that’s enough for a slap.&rdquo; <a class="plink" href="quotable.html#x-8713e36c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-8184fb87">&ldquo;Grail symbols.&rdquo; <a class="plink" href="quotable.html#x-8184fb87" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-c8203d99">&ldquo;Fluey and juicy.&rdquo; <a class="plink" href="quotable.html#x-c8203d99" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-e120cef6">&ldquo;Go ahead and get that TPS report.&rdquo; <a class="plink" href="quotable.html#x-e120cef6" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/sea_bird.html">Sea Bird</a> &middot; 9 AUG 2026</span></li><li id="x-395dd2fd">&ldquo;I am Greek for Greek.&rdquo; <a class="plink" href="quotable.html#x-395dd2fd" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-2fc384ad">&ldquo;Are you Greco or Roman?&rdquo; <em>(proposed as the definitive differentiator)</em> <a class="plink" href="quotable.html#x-2fc384ad" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-a4714925">&ldquo;I’m getting Roman hard.&rdquo; <a class="plink" href="quotable.html#x-a4714925" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-59705ff3">&ldquo;I’m ripped torn because I am ripped torn over that pino.&rdquo; <a class="plink" href="quotable.html#x-59705ff3" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-4d60c78c">&ldquo;I destroyed the evidence. The evidence still exists.&rdquo; <a class="plink" href="quotable.html#x-4d60c78c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-950098e2">&ldquo;You Bogarten your own bread? That’s so uncool.&rdquo; <a class="plink" href="quotable.html#x-950098e2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-9f58dcbc">&ldquo;Unless your name is A.S., it’s not happening.&rdquo; <a class="plink" href="quotable.html#x-9f58dcbc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-9962a021">&ldquo;They provocated. They were the provocateurs.&rdquo; <a class="plink" href="quotable.html#x-9962a021" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-55cc719c">&ldquo;Kill this recording quick.&rdquo; <a class="plink" href="quotable.html#x-55cc719c" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-f344273a">&ldquo;I had to close all the windows so nobody could see me. I got in there with my hands.&rdquo; <em>(The server, on the mushroom burrata)</em> <a class="plink" href="quotable.html#x-f344273a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/nils.html">Nil&#x27;s</a> &middot; 9 AUG 2026</span></li><li id="x-c965b746">&ldquo;Every human being has something of value that they bring to the table. Especially Hitler.&rdquo; <a class="plink" href="quotable.html#x-c965b746" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-fa6574b0">&ldquo;Do you have more room in your body for liquids?&rdquo; <a class="plink" href="quotable.html#x-fa6574b0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-50682668">&ldquo;I think you actually started this, which is why you saw it happen.&rdquo; <em>(the server, on the wheelchair slapping, gesturing cosmically)</em> <a class="plink" href="quotable.html#x-50682668" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-40033d74">&ldquo;T. admits to thinking about probing all dinner.&rdquo; <a class="plink" href="quotable.html#x-40033d74" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-ae8e3b97">&ldquo;I’m gonna need the dog to start wearing a condom.&rdquo; <a class="plink" href="quotable.html#x-ae8e3b97" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-65b0291f">&ldquo;Sparkles&rdquo; <em>(as the running word for sparkling water)</em> <a class="plink" href="quotable.html#x-65b0291f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-2fe2c600">&ldquo;the server’s name being guessed as Landon, Land Death, Ter, and S. before being confirmed as the server&rdquo; <a class="plink" href="quotable.html#x-2fe2c600" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-687d79fe">&ldquo;She’s barking.&rdquo; <em>(Used first about the other waitress, then repurposed for the blue cheese)</em> <a class="plink" href="quotable.html#x-687d79fe" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/circa_1922.html">Circa 1922</a> &middot; 10 AUG 2026</span></li><li id="x-d4072ea3">&ldquo;Risk it for the biscuit, brother&rdquo; <em>(B., after Speaker B worried about grapefruit and his meds)</em> <a class="plink" href="quotable.html#x-d4072ea3" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-6474e5df">&ldquo;Let’s not get too crazy&rdquo; <em>(the server, unprompted)</em> <a class="plink" href="quotable.html#x-6474e5df" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-a5b6cab2">&ldquo;Duck confit sounds fucking fire&rdquo; <a class="plink" href="quotable.html#x-a5b6cab2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-c19312d0">&ldquo;I’m a sucker for a pork chop&rdquo; <em>(said twice, on different nights)</em> <a class="plink" href="quotable.html#x-c19312d0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-c3c5c480">&ldquo;Parsley is the collapse of what a good time&rdquo; <a class="plink" href="quotable.html#x-c3c5c480" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-5983a6e4">&ldquo;I’m gonna ride with that. Pre-felony.&rdquo; <a class="plink" href="quotable.html#x-5983a6e4" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-8043ff8d">&ldquo;I don’t even want to know your name. I’m only going to call you your roster number.&rdquo; <a class="plink" href="quotable.html#x-8043ff8d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-2aa01771">&ldquo;Stays cracking fools 9 to 5&rdquo; <em>(on the chiropractor’s schedule)</em> <a class="plink" href="quotable.html#x-2aa01771" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-5e7ea7c2">&ldquo;What a great job.&rdquo; <em>(on the chiropractor working noon to 5, four days a week)</em> <a class="plink" href="quotable.html#x-5e7ea7c2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-c72cadcb">&ldquo;We can’t reject the null.&rdquo; <em>(on whether Wilmington is actually fancy)</em> <a class="plink" href="quotable.html#x-c72cadcb" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-60a1d8e2">&ldquo;I think the sound man is playing his own playlist to get people to leave.&rdquo; <a class="plink" href="quotable.html#x-60a1d8e2" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/manna.html">Manna</a> &middot; 12 AUG 2026</span></li><li id="x-edec95db">&ldquo;I don’t think I’ve ever met a KISS fan who’s like, oh, I get down.&rdquo; <a class="plink" href="quotable.html#x-edec95db" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-3d535d2d">&ldquo;That’s a red flag.&rdquo; <em>(re: the KISS-loving high school teacher)</em> <a class="plink" href="quotable.html#x-3d535d2d" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-adf35ef3">&ldquo;Jungles Run Deep, bro.&rdquo; <em>(said about ICP, with full confidence)</em> <a class="plink" href="quotable.html#x-adf35ef3" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-b2e123fd">&ldquo;We were the jugglers at Walmart.&rdquo; <a class="plink" href="quotable.html#x-b2e123fd" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-f7f9855a">&ldquo;The files are in the computer.&rdquo; <em>(said while scrolling Discord)</em> <a class="plink" href="quotable.html#x-f7f9855a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-352d985a">&ldquo;I’m starting to sound like Uncle Wade. Oh my God. This is my arc.&rdquo; <a class="plink" href="quotable.html#x-352d985a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-f7f9ffd0">&ldquo;Look at us. We’re having beers on a weekday after going to the thrift store.&rdquo; <a class="plink" href="quotable.html#x-f7f9ffd0" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-629d7222">&ldquo;Who would order eight mini corn dogs?&rdquo; <em>(recurring joke between two people)</em> <a class="plink" href="quotable.html#x-629d7222" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-9777375f">&ldquo;Are you saying that. Is your phone listening to us right now?&rdquo; <em>(after someone said the word communism)</em> <a class="plink" href="quotable.html#x-9777375f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-a09869b8">&ldquo;Chase it, chase it. Skibidi.&rdquo; <a class="plink" href="quotable.html#x-a09869b8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-ac0ad93e">&ldquo;Teachers should be allowed to do cocaine.&rdquo; <a class="plink" href="quotable.html#x-ac0ad93e" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_tree.html">Dram Tree</a> &middot; 13 AUG 2026</span></li><li id="x-0721288f">&ldquo;You need to stop concerning yourself with my well-being.&rdquo; <a class="plink" href="quotable.html#x-0721288f" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-b66dd834">&ldquo;I may now violate several laws. See what’s what.&rdquo; <a class="plink" href="quotable.html#x-b66dd834" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-cd97af75">&ldquo;Chemo banter. That’s not.&rdquo; <a class="plink" href="quotable.html#x-cd97af75" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-6fb767cc">&ldquo;What kind of concrete box we put this beach in?&rdquo; <em>(on funeral banter)</em> <a class="plink" href="quotable.html#x-6fb767cc" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-8eef76d8">&ldquo;Some call him the Rizzler.&rdquo; <a class="plink" href="quotable.html#x-8eef76d8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-16474d54">&ldquo;I’ve never found it. So therefore it doesn’t exist. And by S.’s logic.&rdquo; <a class="plink" href="quotable.html#x-16474d54" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-4fe7db61">&ldquo;I hate this place.&rdquo; <em>(said warmly, immediately after “I love this place” energy)</em> <a class="plink" href="quotable.html#x-4fe7db61" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-5c24229a">&ldquo;Did you have it rolling? I would have given you better content.&rdquo; <em>(closing line, aware the whole time)</em> <a class="plink" href="quotable.html#x-5c24229a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/banter.html">Banter</a> &middot; 13 AUG 2026</span></li><li id="x-bb069542">&ldquo;All input is welcome, just not correct.&rdquo; <em>(A., via text, about the setlist)</em> <a class="plink" href="quotable.html#x-bb069542" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-19ee7cc7">&ldquo;My pronouns are cake talk.&rdquo; <a class="plink" href="quotable.html#x-19ee7cc7" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-049375a8">&ldquo;Lobster. Too flavorful.&rdquo; <em>(recurring complaint about abundance of good things)</em> <a class="plink" href="quotable.html#x-049375a8" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-1b4bfe22">&ldquo;Rent free going away.&rdquo; <em>(about someone still living in someone’s head)</em> <a class="plink" href="quotable.html#x-1b4bfe22" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-911f3cea">&ldquo;We shan’t.&rdquo; <em>(escalating through “we shouldn’t, we could, we may, we shan’t”)</em> <a class="plink" href="quotable.html#x-911f3cea" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-907d7ba5">&ldquo;I’m edging myself as we speak.&rdquo; <em>(re: anticipation for the upcoming show)</em> <a class="plink" href="quotable.html#x-907d7ba5" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-31dc9b4a">&ldquo;Splendid ordering. We’re just living our truths.&rdquo; <a class="plink" href="quotable.html#x-31dc9b4a" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-f251e9e4">&ldquo;She boofed us in the back corner and then she rattled my brain.&rdquo; <a class="plink" href="quotable.html#x-f251e9e4" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-6bca8b27">&ldquo;Cool them jets. I’m at a five. You’re not.&rdquo; <a class="plink" href="quotable.html#x-6bca8b27" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li><li id="x-17e57143">&ldquo;It’s like making a playlist. That’s the only thing I can liken it to.&rdquo; <em>(on ordering adventurously)</em> <a class="plink" href="quotable.html#x-17e57143" aria-label="Link to this item" title="Link to this item">#</a><span class="src"><a href="dinners/dram_yard.html">Dram Yard</a> &middot; 13 AUG 2026</span></li></ul>
+<script>
+var Q = [{"t": "You got away with it. You got away with it.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-dbdd7262"}, {"t": "I wore it this day. And they’d be like. And I’m not lying. I am not lying.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-3f7a1a94"}, {"t": "The cops are already gone. They clock off at 7 here. It’s the wild, wild west until 6am. Budget cuts. The streets, you understand?", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-235f9339"}, {"t": "The streets will protect them.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-fdc3c66e"}, {"t": "He kind of looked like a pedo, but I don’t think that’s enough for a slap.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-8713e36c"}, {"t": "Grail symbols.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-8184fb87"}, {"t": "Fluey and juicy.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-c8203d99"}, {"t": "Go ahead and get that TPS report.", "a": "", "v": "Sea Bird", "d": "9 AUG 2026", "s": "sea_bird", "id": "x-e120cef6"}, {"t": "I am Greek for Greek.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-395dd2fd"}, {"t": "Are you Greco or Roman?", "a": "proposed as the definitive differentiator", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-2fc384ad"}, {"t": "I’m getting Roman hard.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-a4714925"}, {"t": "I’m ripped torn because I am ripped torn over that pino.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-59705ff3"}, {"t": "I destroyed the evidence. The evidence still exists.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-4d60c78c"}, {"t": "You Bogarten your own bread? That’s so uncool.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-950098e2"}, {"t": "Unless your name is A.S., it’s not happening.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-9f58dcbc"}, {"t": "They provocated. They were the provocateurs.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-9962a021"}, {"t": "Kill this recording quick.", "a": "", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-55cc719c"}, {"t": "I had to close all the windows so nobody could see me. I got in there with my hands.", "a": "The server, on the mushroom burrata", "v": "Nil's", "d": "9 AUG 2026", "s": "nils", "id": "x-f344273a"}, {"t": "Every human being has something of value that they bring to the table. Especially Hitler.", "a": "", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-c965b746"}, {"t": "Do you have more room in your body for liquids?", "a": "", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-fa6574b0"}, {"t": "I think you actually started this, which is why you saw it happen.", "a": "the server, on the wheelchair slapping, gesturing cosmically", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-50682668"}, {"t": "T. admits to thinking about probing all dinner.", "a": "", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-40033d74"}, {"t": "I’m gonna need the dog to start wearing a condom.", "a": "", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-ae8e3b97"}, {"t": "Sparkles", "a": "as the running word for sparkling water", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-65b0291f"}, {"t": "the server’s name being guessed as Landon, Land Death, Ter, and S. before being confirmed as the server", "a": "", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-2fe2c600"}, {"t": "She’s barking.", "a": "Used first about the other waitress, then repurposed for the blue cheese", "v": "Circa 1922", "d": "10 AUG 2026", "s": "circa_1922", "id": "x-687d79fe"}, {"t": "Risk it for the biscuit, brother", "a": "B., after Speaker B worried about grapefruit and his meds", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-d4072ea3"}, {"t": "Let’s not get too crazy", "a": "the server, unprompted", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-6474e5df"}, {"t": "Duck confit sounds fucking fire", "a": "", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-a5b6cab2"}, {"t": "I’m a sucker for a pork chop", "a": "said twice, on different nights", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-c19312d0"}, {"t": "Parsley is the collapse of what a good time", "a": "", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-c3c5c480"}, {"t": "I’m gonna ride with that. Pre-felony.", "a": "", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-5983a6e4"}, {"t": "I don’t even want to know your name. I’m only going to call you your roster number.", "a": "", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-8043ff8d"}, {"t": "Stays cracking fools 9 to 5", "a": "on the chiropractor’s schedule", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-2aa01771"}, {"t": "What a great job.", "a": "on the chiropractor working noon to 5, four days a week", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-5e7ea7c2"}, {"t": "We can’t reject the null.", "a": "on whether Wilmington is actually fancy", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-c72cadcb"}, {"t": "I think the sound man is playing his own playlist to get people to leave.", "a": "", "v": "Manna", "d": "12 AUG 2026", "s": "manna", "id": "x-60a1d8e2"}, {"t": "I don’t think I’ve ever met a KISS fan who’s like, oh, I get down.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-edec95db"}, {"t": "That’s a red flag.", "a": "re: the KISS-loving high school teacher", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-3d535d2d"}, {"t": "Jungles Run Deep, bro.", "a": "said about ICP, with full confidence", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-adf35ef3"}, {"t": "We were the jugglers at Walmart.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-b2e123fd"}, {"t": "The files are in the computer.", "a": "said while scrolling Discord", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-f7f9855a"}, {"t": "I’m starting to sound like Uncle Wade. Oh my God. This is my arc.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-352d985a"}, {"t": "Look at us. We’re having beers on a weekday after going to the thrift store.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-f7f9ffd0"}, {"t": "Who would order eight mini corn dogs?", "a": "recurring joke between two people", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-629d7222"}, {"t": "Are you saying that. Is your phone listening to us right now?", "a": "after someone said the word communism", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-9777375f"}, {"t": "Chase it, chase it. Skibidi.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-a09869b8"}, {"t": "Teachers should be allowed to do cocaine.", "a": "", "v": "Dram Tree", "d": "13 AUG 2026", "s": "dram_tree", "id": "x-ac0ad93e"}, {"t": "You need to stop concerning yourself with my well-being.", "a": "", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-0721288f"}, {"t": "I may now violate several laws. See what’s what.", "a": "", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-b66dd834"}, {"t": "Chemo banter. That’s not.", "a": "", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-cd97af75"}, {"t": "What kind of concrete box we put this beach in?", "a": "on funeral banter", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-6fb767cc"}, {"t": "Some call him the Rizzler.", "a": "", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-8eef76d8"}, {"t": "I’ve never found it. So therefore it doesn’t exist. And by S.’s logic.", "a": "", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-16474d54"}, {"t": "I hate this place.", "a": "said warmly, immediately after “I love this place” energy", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-4fe7db61"}, {"t": "Did you have it rolling? I would have given you better content.", "a": "closing line, aware the whole time", "v": "Banter", "d": "13 AUG 2026", "s": "banter", "id": "x-5c24229a"}, {"t": "All input is welcome, just not correct.", "a": "A., via text, about the setlist", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-bb069542"}, {"t": "My pronouns are cake talk.", "a": "", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-19ee7cc7"}, {"t": "Lobster. Too flavorful.", "a": "recurring complaint about abundance of good things", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-049375a8"}, {"t": "Rent free going away.", "a": "about someone still living in someone’s head", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-1b4bfe22"}, {"t": "We shan’t.", "a": "escalating through “we shouldn’t, we could, we may, we shan’t”", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-911f3cea"}, {"t": "I’m edging myself as we speak.", "a": "re: anticipation for the upcoming show", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-907d7ba5"}, {"t": "Splendid ordering. We’re just living our truths.", "a": "", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-31dc9b4a"}, {"t": "She boofed us in the back corner and then she rattled my brain.", "a": "", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-f251e9e4"}, {"t": "Cool them jets. I’m at a five. You’re not.", "a": "", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-6bca8b27"}, {"t": "It’s like making a playlist. That’s the only thing I can liken it to.", "a": "on ordering adventurously", "v": "Dram Yard", "d": "13 AUG 2026", "s": "dram_yard", "id": "x-17e57143"}], last = -1, syncing = false;
+
+function show(i, setHash){
+  last = i;
+  var q = Q[i], slot = document.getElementById('slot');
+  slot.textContent = '';
+  var card = document.createElement('div');
+  card.className = 'exhibit';
+  card.style.width = '100%';
+  var p = document.createElement('p');
+  p.className = 'q';
+  p.textContent = '\u201c' + q.t + '\u201d';
+  card.appendChild(p);
+  if (q.a) {
+    var g = document.createElement('div');
+    g.className = 'gloss'; g.textContent = q.a; card.appendChild(g);
+  }
+  var s = document.createElement('div');
+  s.className = 'src';
+  s.textContent = q.v + ' \u00b7 ' + q.d + ' \u00b7 ';
+  var link = document.createElement('a');
+  link.href = '#' + q.id;
+  link.textContent = 'link to this line';
+  s.appendChild(link);
+  card.appendChild(s);
+  slot.appendChild(card);
+  // Assigning location.hash (not replaceState) so :target follows the card and
+  // the previously linked row stops being highlighted. The scroll position is
+  // restored because the shuffle button is what the reader is looking at.
+  if (setHash && location.hash !== '#' + q.id) {
+    var x = window.pageXOffset, y = window.pageYOffset;
+    syncing = true;
+    location.hash = q.id;
+    window.scrollTo(x, y);
+  }
+}
+
+function pull(){
+  var i = Math.floor(Math.random()*Q.length);
+  if (Q.length > 1) { while (i === last) i = Math.floor(Math.random()*Q.length); }
+  show(i, true);
+}
+
+function fromHash(){
+  var h = location.hash.replace(/^#/, '');
+  if (!h) return -1;
+  for (var i = 0; i < Q.length; i++) { if (Q[i].id === h) return i; }
+  return -1;
+}
+
+document.getElementById('again').addEventListener('click', pull);
+
+var start = fromHash();
+show(start >= 0 ? start : Math.floor(Math.random()*Q.length), false);
+
+window.addEventListener('hashchange', function(){
+  if (syncing) { syncing = false; return; }
+  var i = fromHash();
+  if (i >= 0) show(i, false);
+});
+</script>
+
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/quotable.html
+++ b/the_wilmington_papers/quotable.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Quotable - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/record.html
+++ b/the_wilmington_papers/record.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>The Record - The Wilmington Papers</title>
 <meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<meta name="robots" content="noindex,nofollow">
 <style>
 :root{
   --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;

--- a/the_wilmington_papers/record.html
+++ b/the_wilmington_papers/record.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Record - The Wilmington Papers</title>
+<meta name="description" content="Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.">
+<style>
+:root{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+@media (prefers-color-scheme:dark){
+  :root{ --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+    --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4); }
+}
+:root[data-theme="dark"]{
+  --paper:#16151a; --ink:#e8e4da; --faded:#948c7e; --rule:#38343d;
+  --stamp:#e0705c; --accent:#7fb2a8; --card:#1e1d23; --shadow:rgba(0,0,0,.4);
+}
+:root[data-theme="light"]{
+  --paper:#f4f1e8; --ink:#1c1a17; --faded:#6b6459; --rule:#c9c2b2;
+  --stamp:#a63d2f; --accent:#2f4f4f; --card:#fbf9f3; --shadow:rgba(28,26,23,.09);
+}
+*{box-sizing:border-box}
+body{
+  margin:0; background:var(--paper); color:var(--ink);
+  font-family:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+  line-height:1.6; -webkit-font-smoothing:antialiased;
+}
+a{color:inherit}
+.wrap{max-width:820px;margin:0 auto;padding:0 22px 90px}
+.mono{font-family:"SFMono-Regular",Menlo,Consolas,monospace}
+
+header.mast{border-bottom:2px solid var(--ink);margin-bottom:26px;padding-top:38px}
+.kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:12px;
+}
+h1.title{
+  font-size:clamp(2.1rem,7vw,3.5rem);line-height:1.02;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+.dek{color:var(--faded);font-size:.95rem;margin:0 0 20px;font-style:italic}
+.mast-meta{
+  display:flex;flex-wrap:wrap;gap:6px 20px;padding:10px 0;
+  border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.mast-meta b{color:var(--ink);font-weight:600}
+
+nav.tabs{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 34px;align-items:center}
+nav.tabs a{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.1em;text-transform:uppercase;
+  text-decoration:none;padding:7px 13px;border:1px solid var(--rule);
+  border-radius:2px;color:var(--faded);background:var(--card);
+}
+nav.tabs a:hover{border-color:var(--ink);color:var(--ink)}
+nav.tabs a[aria-current="page"]{
+  background:var(--ink);color:var(--paper);border-color:var(--ink);
+}
+nav.tabs a.themer{margin-left:auto;border-style:dashed}
+
+h2.sec{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.7rem;letter-spacing:.2em;text-transform:uppercase;
+  color:var(--stamp);margin:44px 0 4px;
+}
+h2.sec + .sec-note{color:var(--faded);font-size:.85rem;margin:0 0 18px;font-style:italic}
+.rule{height:1px;background:var(--rule);border:0;margin:0 0 20px}
+.quiet{color:var(--faded);font-style:italic}
+
+.exhibit{
+  background:var(--card);border:1px solid var(--rule);border-left:3px solid var(--stamp);
+  padding:22px 24px;margin:0 0 16px;border-radius:2px;box-shadow:0 1px 2px var(--shadow);
+}
+.exhibit .q{font-size:1.28rem;line-height:1.44;margin:0 0 12px}
+.exhibit .src{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;color:var(--faded);
+}
+.exhibit .gloss{color:var(--faded);font-size:.86rem;font-style:italic;margin-top:6px}
+
+.docket{display:grid;gap:12px}
+.doc{
+  display:grid;grid-template-columns:44px 1fr auto;gap:16px;align-items:baseline;
+  background:var(--card);border:1px solid var(--rule);border-radius:2px;
+  padding:16px 18px;text-decoration:none;transition:border-color .15s,transform .15s;
+}
+.doc:hover{border-color:var(--ink);transform:translateX(2px)}
+.doc .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.72rem;color:var(--stamp);letter-spacing:.06em;
+}
+.doc .v{font-size:1.16rem;font-weight:600;margin:0 0 2px}
+.doc .k{color:var(--faded);font-size:.82rem}
+.doc .d{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;color:var(--faded);letter-spacing:.08em;white-space:nowrap;
+}
+.doc .tally{
+  margin-top:8px;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+  display:block;
+}
+@media(max-width:560px){
+  .doc{grid-template-columns:34px 1fr;gap:10px}
+  .doc .d{grid-column:2;margin-top:4px}
+}
+
+.thread{
+  border:1px solid var(--rule);border-radius:2px;background:var(--card);
+  padding:16px 18px;margin-bottom:12px;
+}
+.thread h3{
+  margin:0 0 6px;font-size:1.05rem;display:flex;justify-content:space-between;
+  align-items:baseline;gap:12px;flex-wrap:wrap;
+}
+.thread .count{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.62rem;
+  letter-spacing:.12em;text-transform:uppercase;color:var(--stamp);
+}
+.thread .where{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  color:var(--faded);letter-spacing:.06em;
+}
+
+ul.evid{list-style:none;padding:0;margin:0}
+ul.evid li{padding:12px 0 12px 30px;border-bottom:1px solid var(--rule);position:relative}
+ul.evid li:last-child{border-bottom:0}
+ul.evid li:before{
+  content:"?";position:absolute;left:0;top:12px;color:var(--stamp);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.8rem;font-weight:700;
+}
+ul.evid.loop li:before{content:"\21bb"}
+ul.evid.claim li:before{content:"\00a7";color:var(--accent)}
+ul.evid.quest li:before{content:"\2192";color:var(--accent)}
+ul.evid .src{
+  display:block;margin-top:5px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+
+a.plink{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  text-decoration:none;color:var(--faded);opacity:0;
+  padding:0 4px;font-size:.85em;transition:opacity .12s;
+  white-space:nowrap;
+}
+li:hover > a.plink,a.plink:focus{opacity:1;color:var(--stamp)}
+@media (hover:none){ a.plink{opacity:.5} }
+
+/* Highlight without reflowing: the row keeps its 30px text indent and the
+   marker keeps its position, so only the background and rail change. */
+ul.evid li{border-left:3px solid transparent;padding-left:30px}
+ul.evid li:before{left:3px}
+ul.evid li:target{
+  background:var(--card);
+  border-left-color:var(--stamp);
+  padding-right:12px;
+}
+ul.evid li:target > a.plink{opacity:1;color:var(--stamp)}
+.exhibit .src a{color:var(--faded);text-decoration:underline}
+.exhibit .src a:hover{color:var(--stamp)}
+.exhibit:target{border-left-width:6px;background:var(--paper)}
+.exhibit:hover > .q > a.plink,.exhibit:target > .q > a.plink{opacity:1;color:var(--stamp)}
+:target{scroll-margin-top:24px}
+
+.dinner-head{border-bottom:2px solid var(--ink);padding-top:34px;margin-bottom:8px}
+.dinner-head .num{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.66rem;
+  letter-spacing:.2em;text-transform:uppercase;color:var(--stamp);margin-bottom:10px;
+}
+.dinner-head h1{font-size:clamp(1.9rem,6vw,3rem);margin:0 0 8px;letter-spacing:-.02em}
+.dinner-head .sub{color:var(--faded);font-size:.9rem;margin:0 0 18px}
+.setting{font-size:1.02rem;margin:22px 0 0}
+.undercurrent{
+  border-left:3px solid var(--accent);background:var(--card);
+  padding:16px 20px;margin:8px 0 0;font-size:.98rem;
+}
+ul.plain{padding-left:20px;margin:0}
+ul.plain li{margin-bottom:9px}
+.pager{
+  display:flex;justify-content:space-between;gap:14px;margin-top:52px;
+  padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.08em;text-transform:uppercase;
+}
+.pager a{color:var(--faded);text-decoration:none}
+.pager a:hover{color:var(--ink)}
+
+#slot{min-height:190px;display:flex;align-items:center}
+.btn{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.68rem;
+  letter-spacing:.14em;text-transform:uppercase;cursor:pointer;
+  background:var(--ink);color:var(--paper);border:0;border-radius:2px;padding:11px 20px;
+}
+.btn:hover{opacity:.86}
+footer.foot{
+  margin-top:60px;padding-top:18px;border-top:1px solid var(--rule);
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.64rem;
+  letter-spacing:.1em;text-transform:uppercase;color:var(--faded);
+}
+footer.foot a{color:var(--faded)}
+.stat-row{display:flex;flex-wrap:wrap;gap:26px;margin:26px 0 0}
+.stat b{
+  display:block;font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:1.7rem;color:var(--stamp);line-height:1;font-weight:600;
+}
+.stat span{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+<nav class="tabs"><a href="index.html">The Case</a><a href="record.html" aria-current="page">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
+
+<header class="mast">
+  <div class="kicker">Section II</div>
+  <h1 class="title">The Record</h1>
+  <p class="dek">Seven sittings, chronological. Each one catalogued in full.</p>
+</header>
+<div class="docket">  <a class="doc" href="dinners/sea_bird.html">
+    <span class="num">I</span>
+    <span><span class="v">Sea Bird</span><br><span class="k">Outdoor bar</span>
+      <span class="tally">8 lines &middot; 4 unanswered &middot; 6 claims</span></span>
+    <span class="d">9 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/nils.html">
+    <span class="num">II</span>
+    <span><span class="v">Nil&#x27;s</span><br><span class="k">Greek, downtown</span>
+      <span class="tally">10 lines &middot; 7 unanswered &middot; 6 claims</span></span>
+    <span class="d">9 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/circa_1922.html">
+    <span class="num">III</span>
+    <span><span class="v">Circa 1922</span><br><span class="k">American bistro</span>
+      <span class="tally">8 lines &middot; 7 unanswered &middot; 9 claims</span></span>
+    <span class="d">10 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/manna.html">
+    <span class="num">IV</span>
+    <span><span class="v">Manna</span><br><span class="k">Farm-to-table, Princess St</span>
+      <span class="tally">11 lines &middot; 8 unanswered &middot; 9 claims</span></span>
+    <span class="d">12 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/dram_tree.html">
+    <span class="num">V</span>
+    <span><span class="v">Dram Tree</span><br><span class="k">Weekday beers</span>
+      <span class="tally">11 lines &middot; 6 unanswered &middot; 10 claims</span></span>
+    <span class="d">13 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/banter.html">
+    <span class="num">VI</span>
+    <span><span class="v">Banter</span><br><span class="k">English-style pub</span>
+      <span class="tally">8 lines &middot; 6 unanswered &middot; 9 claims</span></span>
+    <span class="d">13 AUG 2026</span>
+  </a>
+  <a class="doc" href="dinners/dram_yard.html">
+    <span class="num">VII</span>
+    <span><span class="v">Dram Yard</span><br><span class="k">Late dinner, Market St</span>
+      <span class="tally">10 lines &middot; 6 unanswered &middot; 7 claims</span></span>
+    <span class="d">13 AUG 2026</span>
+  </a>
+</div>
+<footer class="foot">
+  The Wilmington Papers &middot; field notes, Aug 2026 &middot; <a href="index.html">return to file</a>
+</footer>
+</div>
+<script>
+(function(){
+  var r=document.documentElement, k="papers-theme", b=document.getElementById("themer");
+  try{ var s=localStorage.getItem(k); if(s) r.setAttribute("data-theme",s); }catch(e){}
+  if(!b) return;
+  b.addEventListener("click",function(ev){
+    ev.preventDefault();
+    var cur=r.getAttribute("data-theme");
+    if(!cur) cur=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";
+    var next=cur==="dark"?"light":"dark";
+    r.setAttribute("data-theme",next);
+    try{ localStorage.setItem(k,next); }catch(e){}
+  });
+})();
+</script>
+</body>
+</html>

--- a/the_wilmington_papers/trip.json
+++ b/the_wilmington_papers/trip.json
@@ -3,7 +3,7 @@
   "tagline": "Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.",
   "footer": "field notes, Aug 2026",
   "notes_dir": "granola_notes",
-  "noindex": false,
+  "noindex": true,
   "facts": [
     {
       "n": 1,

--- a/the_wilmington_papers/trip.json
+++ b/the_wilmington_papers/trip.json
@@ -1,0 +1,90 @@
+{
+  "title": "The Wilmington Papers",
+  "tagline": "Seven dinners in Wilmington, North Carolina. Transcribed without consent, catalogued without mercy. Nothing was resolved.",
+  "footer": "field notes, Aug 2026",
+  "notes_dir": "granola_notes",
+  "noindex": false,
+  "facts": [
+    {
+      "n": 1,
+      "label": "unresolved slap"
+    }
+  ],
+  "closing_stat": {
+    "n": 0,
+    "label": "firm decisions"
+  },
+  "drop_sections": [
+    "undercurrent"
+  ],
+  "order": [
+    "sea_bird",
+    "nils",
+    "circa_1922",
+    "manna",
+    "dram_tree",
+    "banter",
+    "dram_yard"
+  ],
+  "venues": {
+    "sea_bird": {
+      "name": "Sea Bird",
+      "kind": "Outdoor bar"
+    },
+    "nils": {
+      "name": "Nil's",
+      "kind": "Greek, downtown"
+    },
+    "circa_1922": {
+      "name": "Circa 1922",
+      "kind": "American bistro"
+    },
+    "manna": {
+      "name": "Manna",
+      "kind": "Farm-to-table, Princess St"
+    },
+    "dram_tree": {
+      "name": "Dram Tree",
+      "kind": "Weekday beers"
+    },
+    "banter": {
+      "name": "Banter",
+      "kind": "English-style pub"
+    },
+    "dram_yard": {
+      "name": "Dram Yard",
+      "kind": "Late dinner, Market St"
+    }
+  },
+  "thread_min_sittings": 2,
+  "threads": {
+    "the slap": "wheelchair|slap",
+    "the brass rabbit": "brass rabbit|the rabbit",
+    "city tiers": "S-tier|A-tier|tier",
+    "the set list": "set ?list",
+    "bidets": "bidet",
+    "cymbals": "cymbal"
+  },
+  "sections": {
+    "cold_cases": {
+      "kicker": "Section I - unresolved",
+      "title": "Cold Cases",
+      "dek": "{questions} questions asked and never answered. {loops} loops left open. No one is working on any of this."
+    },
+    "record": {
+      "kicker": "Section II",
+      "title": "The Record",
+      "dek": "Seven sittings, chronological. Each one catalogued in full."
+    },
+    "canon": {
+      "kicker": "Section III - the record of claims",
+      "title": "Canon",
+      "dek": "{theories} assertions made at the table with total confidence and zero verification. Presented here as fact, because that is how they were said."
+    },
+    "quotable": {
+      "kicker": "Section IV",
+      "title": "Quotable",
+      "dek": "Every line worth preserving, served one at a time."
+    }
+  }
+}


### PR DESCRIPTION
Seven dinners of Granola notes turned into a static case-file site, plus a
reusable generator so the next trip is config instead of code.

Live at `hjeebus.com/the_wilmington_papers/` once merged.

## What this adds

The notes share a rigid schema across every sitting (Best Lines, Theories and
Claims, Unanswered Questions, Open Loops, Emotional Undercurrents), so the site
cuts *across* the dinners rather than just listing them:

- **Cold Cases** — all 44 unanswered questions and 31 open loops, each linked
  back to its dinner
- **Canon** — the 56 claims asserted confidently and verified never
- **Quotable** — all 66 lines, one at a time
- **The Record** — the seven dinners in full, with prev/next paging

The home page tracks subjects recurring across sittings by regex; the slap
turns up in four separate dinners.

## Tooling

`_tools/papers/` holds the generator. Adding a trip:

```
mkdir -p the_reno_papers/granola_notes    # notes go here
# write the_reno_papers/trip.json
python3 _tools/papers/build.py the_reno_papers
```

Every reader-visible string lives in `trip.json`. Venue names and dates derive
from each note's own H1 and byline, so no per-trip code. Unrecognized sections
render at the foot of the dinner page instead of being dropped. Full config
table in `_tools/papers/README.md`.

## Verification

- All 12 pages: valid tag nesting, zero broken internal links, JS syntax checked
- Content ships in the markup, so every page works with JavaScript disabled —
  the theme toggle and quote shuffle are progressive enhancement
- Ran a second trip with different people and no config through the generator,
  which caught two parser bugs: straight apostrophes truncated a quote at the
  first `'`, and attributions containing their own quotes swallowed the rest of
  the bullet. Both fixed, unit-tested against ten edge cases
- Also verified notes with no byline, no date, missing sections, and unknown
  sections
- The quote shuffle uses `textContent`, not `innerHTML`, so a line containing
  markup cannot inject

`dram_yard.md` held five byte-identical copies of the same note (same Granola
transcript id) and is reduced to one.

## Note before merging

These notes are candid — `nils.md` has a section on a relationship, and real
names run throughout. Merging publishes all of it to a public domain. There's a
`"noindex": true` flag in `trip.json` to keep it out of search results; it is
currently `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)