### PR TITLE
feat(papers): passphrase gate for trip sites

### DIFF
--- a/_tools/papers/README.md
+++ b/_tools/papers/README.md
@@ -57,6 +57,7 @@ time. The `file` column says where each key goes.
 | `thread_min_sittings` | public | Sittings a thread needs to appear (default 2) |
 | `sections` | public | Per-page `kicker` / `title` / `dek` overrides |
 | `drop_sections` | public | Section field names to omit entirely |
+| `gate` | both | Passphrase splash; `passphrase` is **private**, display strings public |
 | `hero_quote` | **private** | Prefix of the line to feature as Exhibit A |
 | `companion_aliases` | **private** | `{"Real Name": ["variant", ...]}` spelling fixes |
 | `redact_names` | **private** | `{"Real Name": "stand-in"}` replacements |
@@ -147,6 +148,60 @@ nofollow">` to every page of that trip. Useful when the notes cover events that
 are searchable in their own right — anonymizing the guests does nothing about
 the incidents around them. It keeps the pages live and link-shareable while
 keeping them out of results, and it is reversible with a rebuild.
+
+## The passphrase gate
+
+A trip can put a splash screen in front of every one of its pages:
+
+```json
+"gate": {
+  "kicker": "Sealed - not for circulation",
+  "dek": "The file is closed to the general public. State the phrase.",
+  "placeholder": "the phrase",
+  "hint": "A palindrome. Asked of waterfowl."
+}
+```
+
+with the phrase itself in `trip.private.json`:
+
+```json
+"gate": { "passphrase": "<the phrase>" }
+```
+
+Only the SHA-256 digest reaches the generated pages, so the passphrase is not
+recoverable by reading the source. Comparison happens in the browser via
+`crypto.subtle`. Input is lowercased and trimmed before hashing, so casing and
+stray surrounding space do not matter, but **punctuation is significant** — a
+phrase ending in `?` has to be typed with the `?`. A correct entry is remembered
+in `sessionStorage`, so moving between pages does not re-prompt, and closing the
+tab re-seals the file.
+
+The phrase is deliberately absent from this README: an example here would be
+committed, and a committed passphrase is a published one.
+
+The passphrase belongs in the private file for the same reason the name map
+does: committing it to a public repo publishes it. Omit the `gate` key entirely
+and pages build ungated.
+
+### What the gate is not
+
+**It is a doorway, not a lock, and it protects nothing.** GitHub Pages serves
+static files with no server to check anything, so the gate can only hide content
+the browser has already been given. Every gated page ships its full text and
+stays readable through view-source, devtools, or `curl` of the page URL. The
+digest resists casual source-reading, but a recognizable phrase falls to a
+wordlist regardless.
+
+So use it to set a tone and turn away casual arrivals. Do not use it to publish
+anything that would be a problem to read — for that, the controls that actually
+work are `suppress`, `redact_names`, `drop_sections`, and not committing the
+material at all. `noindex` remains the thing that keeps pages out of search
+results; the gate does not help there and is not a substitute.
+
+If a trip ever genuinely needs closed contents on this host, the shape that
+works is encrypting the page bodies with the passphrase and decrypting on
+submit, so ciphertext is all that ships. That trades away the deep links below
+and is deliberately not built.
 
 ## Deep links
 

--- a/_tools/papers/build.py
+++ b/_tools/papers/build.py
@@ -22,7 +22,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from parse import load_trip
-from theme import CSS, TABS, THEME_JS
+from theme import CSS, GATE_CSS, GATE_JS, TABS, THEME_JS
 
 ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII",
          "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX"]
@@ -34,6 +34,7 @@ DEFAULTS = {
     "tagline": "Dinners, transcribed and entered into evidence.",
     "footer": "field notes",
     "noindex": False,
+    "gate": None,
     "sections": {
         "cold_cases": {
             "kicker": "Section I - unresolved",
@@ -61,6 +62,51 @@ DEFAULTS = {
 
 def e(s):
     return html.escape(str(s), quote=True)
+
+
+def gate_norm(s):
+    """Normalize a passphrase before hashing: casing and surrounding space only.
+
+    Punctuation is significant, so a phrase ending in `?` must be typed with it.
+    Applied identically here and in GATE_JS, so a digest built at generation
+    time matches what the browser computes from what the reader types.
+    """
+    return str(s).lower().strip()
+
+
+def gate_digest(cfg):
+    """SHA-256 of the configured passphrase, or "" when no gate is configured.
+
+    Hashing keeps the passphrase itself out of the generated pages. It does not
+    protect the pages: the body ships alongside the gate and stays readable via
+    view-source, devtools, or a direct fetch of any page URL.
+    """
+    g = cfg.get("gate") or {}
+    phrase = g.get("passphrase") or ""
+    if not phrase:
+        return ""
+    return hashlib.sha256(gate_norm(phrase).encode("utf-8")).hexdigest()
+
+
+def gate_markup(cfg, digest):
+    """Splash overlay plus the script that removes it, or "" when ungated."""
+    if not digest:
+        return "", ""
+    g = cfg.get("gate") or {}
+    overlay = (
+        '<div id="gate"><div class="box">'
+        '<div class="kicker">' + e(g.get("kicker", "Restricted · not for circulation")) + "</div>"
+        "<h1>" + e(g.get("title") or cfg["title"]) + "</h1>"
+        '<p class="dek">' + e(g.get("dek", "This file is closed. State the phrase.")) + "</p>"
+        '<form id="gate-form"><input id="gate-input" type="text" '
+        'autocomplete="off" autocapitalize="none" spellcheck="false" '
+        'aria-label="Passphrase" placeholder="' + e(g.get("placeholder", "passphrase")) + '">'
+        '<button class="btn" type="submit">Enter</button></form>'
+        '<p class="err" id="gate-err" role="status" aria-live="polite"></p>'
+        + ('<p class="hint">' + e(g["hint"]) + "</p>" if g.get("hint") else "")
+        + "</div></div>"
+    )
+    return overlay, GATE_JS.replace("%%DIGEST%%", digest)
 
 
 def merge(base, over):
@@ -126,17 +172,24 @@ def page(cfg, title, body, current, depth=0):
     tabs += '<a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a>'
     robots = ('\n<meta name="robots" content="noindex,nofollow">'
               if cfg.get("noindex") else "")
+    digest = gate_digest(cfg)
+    overlay, gate_js = gate_markup(cfg, digest)
+    # The class is inline on <html> rather than set by script so a gated page
+    # never paints its contents before the gate is evaluated.
+    html_attrs = ' class="gated"' if digest else ""
+    css = CSS + (GATE_CSS if digest else "")
     return """<!doctype html>
-<html lang="en">
+<html lang="en"%s>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>%s</title>
 <meta name="description" content="%s">%s
 <style>%s</style>
+<script>%s</script>
 </head>
 <body>
-<div class="wrap">
+%s<div class="wrap">
 <nav class="tabs">%s</nav>
 %s
 <footer class="foot">
@@ -146,8 +199,8 @@ def page(cfg, title, body, current, depth=0):
 <script>%s</script>
 </body>
 </html>
-""" % (e(title), e(cfg["tagline"][:150]), robots, CSS, tabs, body,
-       e(cfg["title"]), e(cfg["footer"]), up, THEME_JS)
+""" % (html_attrs, e(title), e(cfg["tagline"][:150]), robots, css, gate_js,
+       overlay, tabs, body, e(cfg["title"]), e(cfg["footer"]), up, THEME_JS)
 
 
 def suffix(cfg):

--- a/_tools/papers/theme.py
+++ b/_tools/papers/theme.py
@@ -3,6 +3,12 @@
 `CSS` is emitted inline so a generated trip folder is fully self-contained and
 needs no asset paths. Palettes respond to `prefers-color-scheme` and to an
 explicit `data-theme` attribute, which the footer toggle persists.
+
+`GATE_CSS` and `GATE_JS` render the optional passphrase splash. The gate is a
+doorway, not a lock: it compares a SHA-256 digest so the passphrase itself is
+absent from the source, but the page body ships to the browser either way and is
+readable through view-source, devtools, or a direct fetch. Treat it as a way to
+set a tone and turn away casual arrivals, never as protection for the contents.
 """
 
 CSS = """
@@ -214,6 +220,88 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+"""
+
+GATE_CSS = """
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
+"""
+
+GATE_JS = """
+(function(){
+  var DIGEST="%%DIGEST%%", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
 """
 
 THEME_JS = """

--- a/the_wilmington_papers/canon.html
+++ b/the_wilmington_papers/canon.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html" aria-current="page">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="mast">

--- a/the_wilmington_papers/cold-cases.html
+++ b/the_wilmington_papers/cold-cases.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html" aria-current="page">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="mast">

--- a/the_wilmington_papers/dinners/banter.html
+++ b/the_wilmington_papers/dinners/banter.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/circa_1922.html
+++ b/the_wilmington_papers/dinners/circa_1922.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/dram_tree.html
+++ b/the_wilmington_papers/dinners/dram_tree.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/dram_yard.html
+++ b/the_wilmington_papers/dinners/dram_yard.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/kipos.html
+++ b/the_wilmington_papers/dinners/kipos.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/manna.html
+++ b/the_wilmington_papers/dinners/manna.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/nils.html
+++ b/the_wilmington_papers/dinners/nils.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/dinners/sea_bird.html
+++ b/the_wilmington_papers/dinners/sea_bird.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="../index.html">The Case</a><a href="../record.html" aria-current="page">The Record</a><a href="../cold-cases.html">Cold Cases</a><a href="../canon.html">Canon</a><a href="../quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="dinner-head">

--- a/the_wilmington_papers/index.html
+++ b/the_wilmington_papers/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="index.html" aria-current="page">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="mast">

--- a/the_wilmington_papers/quotable.html
+++ b/the_wilmington_papers/quotable.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="index.html">The Case</a><a href="record.html">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html" aria-current="page">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="mast">

--- a/the_wilmington_papers/record.html
+++ b/the_wilmington_papers/record.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="gated">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -215,10 +215,89 @@ footer.foot a{color:var(--faded)}
   font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.6rem;
   letter-spacing:.14em;text-transform:uppercase;color:var(--faded);
 }
+
+html.gated body > .wrap{display:none}
+html.gated{background:var(--paper)}
+#gate{
+  position:fixed;inset:0;z-index:9999;background:var(--paper);color:var(--ink);
+  display:flex;align-items:center;justify-content:center;padding:28px;
+}
+#gate .box{max-width:440px;width:100%}
+#gate .kicker{
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;
+  color:var(--stamp);margin-bottom:14px;
+}
+#gate h1{
+  font-size:clamp(1.7rem,5vw,2.4rem);line-height:1.08;margin:0 0 10px;
+  letter-spacing:-.02em;font-weight:600;
+}
+#gate .dek{color:var(--faded);font-size:.92rem;font-style:italic;margin:0 0 24px}
+#gate form{display:flex;gap:8px;flex-wrap:wrap;border-top:1px solid var(--rule);padding-top:20px}
+#gate input{
+  flex:1 1 200px;background:var(--card);color:var(--ink);
+  border:1px solid var(--rule);border-radius:2px;padding:11px 13px;
+  font-family:"SFMono-Regular",Menlo,Consolas,monospace;font-size:.82rem;
+}
+#gate input:focus{outline:0;border-color:var(--ink)}
+#gate .err{
+  color:var(--stamp);font-family:"SFMono-Regular",Menlo,Consolas,monospace;
+  font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;
+  margin:14px 0 0;min-height:1em;
+}
+#gate .hint{color:var(--faded);font-size:.8rem;font-style:italic;margin:18px 0 0}
 </style>
+<script>
+(function(){
+  var DIGEST="02f5f96fc7f9d50a47c16d7568bf1f7a09b25514e7242968f65fa6bb56acb2ae", KEY="papers-gate", r=document.documentElement;
+  function norm(s){ return s.toLowerCase().trim(); }
+  function hex(buf){
+    var out="", v=new Uint8Array(buf);
+    for(var i=0;i<v.length;i++) out += v[i].toString(16).padStart(2,"0");
+    return out;
+  }
+  function drop(){
+    var g=document.getElementById("gate");
+    if(g) g.parentNode.removeChild(g);
+  }
+  // This runs in <head>, so the overlay may not exist yet; unhide immediately
+  // and defer the node removal to whenever the document is ready.
+  function open_(){
+    r.classList.remove("gated");
+    if(document.readyState==="loading") document.addEventListener("DOMContentLoaded",drop);
+    else drop();
+  }
+  try{ if(sessionStorage.getItem(KEY)===DIGEST){ open_(); return; } }catch(e){}
+
+  // No SubtleCrypto (file:// or an old browser) leaves nothing to compare
+  // against, and a gate that cannot be opened is worse than no gate.
+  var subtle = window.crypto && window.crypto.subtle;
+  if(!subtle){ open_(); return; }
+
+  document.addEventListener("DOMContentLoaded", function(){
+    var f=document.getElementById("gate-form");
+    if(!f) return;
+    f.addEventListener("submit", function(ev){
+      ev.preventDefault();
+      var input=document.getElementById("gate-input");
+      var err=document.getElementById("gate-err");
+      subtle.digest("SHA-256", new TextEncoder().encode(norm(input.value)))
+        .then(function(buf){
+          if(hex(buf)===DIGEST){
+            try{ sessionStorage.setItem(KEY,DIGEST); }catch(e){}
+            open_();
+          }else{
+            err.textContent="Not the phrase. Try again.";
+            input.value=""; input.focus();
+          }
+        });
+    });
+  });
+})();
+</script>
 </head>
 <body>
-<div class="wrap">
+<div id="gate"><div class="box"><div class="kicker">Sealed · not for circulation</div><h1>The Wilmington Papers</h1><p class="dek">The file is closed to the general public. State the phrase.</p><form id="gate-form"><input id="gate-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" aria-label="Passphrase" placeholder="the phrase"><button class="btn" type="submit">Enter</button></form><p class="err" id="gate-err" role="status" aria-live="polite"></p><p class="hint">A palindrome. Asked of waterfowl.</p></div></div><div class="wrap">
 <nav class="tabs"><a href="index.html">The Case</a><a href="record.html" aria-current="page">The Record</a><a href="cold-cases.html">Cold Cases</a><a href="canon.html">Canon</a><a href="quotable.html">Quotable</a><a class="themer" href="#" id="themer" title="Toggle light and dark">&#9686;</a></nav>
 
 <header class="mast">

--- a/the_wilmington_papers/trip.json
+++ b/the_wilmington_papers/trip.json
@@ -4,6 +4,12 @@
   "footer": "field notes, Aug 2026",
   "notes_dir": "granola_notes",
   "noindex": true,
+  "gate": {
+    "kicker": "Sealed · not for circulation",
+    "dek": "The file is closed to the general public. State the phrase.",
+    "placeholder": "the phrase",
+    "hint": "A palindrome. Asked of waterfowl."
+  },
   "facts": [
     {
       "n": 1,


### PR DESCRIPTION
Adds an optional passphrase splash screen to the papers generator, enabled for The Wilmington Papers.

## What it does

`build.py` hashes the configured passphrase at generation time and ships only the SHA-256 digest. The browser hashes what the reader types via `crypto.subtle` and compares — the phrase itself never appears in the generated pages, so it is not recoverable by reading the source.

Enabled per trip with a `gate` block; omit it and pages build ungated exactly as before.

- Passphrase lives in `trip.private.json` (gitignored), for the same reason the name map does: committing it to a public repo publishes it.
- Display strings (kicker, dek, placeholder, hint) live in `trip.json` with the rest of the reader-visible text.
- Input is lowercased and trimmed, so casing and stray surrounding space are forgiven. Punctuation is significant — a phrase ending in `?` must be typed with it.
- A correct entry is held in `sessionStorage`, so moving between pages does not re-prompt and closing the tab re-seals the file.
- Without `crypto.subtle` (`file://`, older browsers) the gate opens rather than trapping the reader behind a check it cannot perform.

## This is a doorway, not a lock

Worth being explicit, since the name invites the wrong assumption: **the gate protects nothing.** Static hosting has no server to check anything, so every gated page still ships its full body and stays readable through view-source, devtools, or a direct fetch of any page URL. Hashing hides the passphrase from a source-reader; it does nothing for the content.

The controls that actually withhold material are unchanged and still the real ones: `suppress`, `redact_names`, `drop_sections`, and not committing the notes. `noindex` remains what keeps pages out of search results — the gate is not a substitute. The README says all of this next to the config so the limitation travels with the feature.

If a trip ever needs genuinely closed contents on this host, the shape that works is encrypting page bodies and decrypting on submit. That trades away the deep links and is deliberately not built.

## Verification

- Extracted the `norm()`/`hex()` functions from a generated page and ran the shipped logic against 9 inputs — exact phrase, casing and whitespace variants, missing/extra/wrong punctuation, wrong phrase, empty. All behaved as intended.
- Confirmed the digest on all 13 pages matches the hash of the phrase computed independently, before any normalization existed.
- Confirmed the Python and JS normalizers are semantically identical; divergence would silently lock readers out.
- Redaction audit clean: no configured real name and no suppressed topic appears in any tracked file.
- Passphrase absent from every tracked file and from all remote history; `trip.private.json` untracked.
- Build remains idempotent; deep-link ids, `noindex`, and the theme toggle unchanged.

## Note on merging

`master` serves GitHub Pages, so merging publishes the 13 gated pages to `www.hjeeb.us/the_wilmington_papers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)